### PR TITLE
Upgrade search engine to latest version

### DIFF
--- a/milvus-compose.yaml
+++ b/milvus-compose.yaml
@@ -34,7 +34,7 @@ services:
 
   standalone:
     container_name: benchmark_milvus-standalone
-    image: milvusdb/milvus:v2.5.4
+    image: milvusdb/milvus:v2.6.7
     command: ["milvus", "run", "standalone"]
     security_opt:
     - seccomp:unconfined

--- a/src/search_ann_benchmark/engines/elasticsearch.py
+++ b/src/search_ann_benchmark/engines/elasticsearch.py
@@ -22,7 +22,7 @@ class ElasticsearchConfig(EngineConfig):
     name: str = "elasticsearch"
     host: str = "localhost"
     port: int = 9211
-    version: str = "8.17.4"
+    version: str = "8.17.8"
     container_name: str = "benchmark_es"
     heap: str = "2g"
 

--- a/src/search_ann_benchmark/engines/milvus.py
+++ b/src/search_ann_benchmark/engines/milvus.py
@@ -24,7 +24,7 @@ class MilvusConfig(EngineConfig):
     name: str = "milvus"
     host: str = "localhost"
     port: int = 19540
-    version: str = "2.5.4"
+    version: str = "2.6.7"
     container_name: str = "benchmark_milvus"
     etcd_version: str = "3.5.5"
     minio_version: str = "RELEASE.2023-03-20T20-16-18Z"

--- a/src/search_ann_benchmark/engines/opensearch.py
+++ b/src/search_ann_benchmark/engines/opensearch.py
@@ -23,7 +23,7 @@ class OpenSearchConfig(EngineConfig):
     name: str = "opensearch"
     host: str = "localhost"
     port: int = 9212
-    version: str = "2.19.1"
+    version: str = "2.19.4"
     container_name: str = "benchmark_opensearch"
     heap: str = "2g"
     engine: str = "lucene"  # or "faiss"

--- a/src/search_ann_benchmark/engines/pgvector.py
+++ b/src/search_ann_benchmark/engines/pgvector.py
@@ -19,7 +19,7 @@ class PgvectorConfig(EngineConfig):
     name: str = "pgvector"
     host: str = "localhost"
     port: int = 5433
-    version: str = "0.8.0-pg17"
+    version: str = "0.8.1-pg17"
     container_name: str = "benchmark_pgvector"
     password: str = "ann!test123"
     dbname: str = "vectordb"

--- a/src/search_ann_benchmark/engines/qdrant.py
+++ b/src/search_ann_benchmark/engines/qdrant.py
@@ -22,7 +22,7 @@ class QdrantConfig(EngineConfig):
     name: str = "qdrant"
     host: str = "localhost"
     port: int = 6344
-    version: str = "1.13.6"
+    version: str = "1.16.2"
     container_name: str = "benchmark_qdrant"
 
 

--- a/src/search_ann_benchmark/engines/vespa.py
+++ b/src/search_ann_benchmark/engines/vespa.py
@@ -30,7 +30,7 @@ class VespaConfig(EngineConfig):
     name: str = "vespa"
     host: str = "localhost"
     port: int = 8090
-    version: str = "8.499.20"
+    version: str = "8.596.20"
     container_name: str = "benchmark_vespa"
     management_port: int = 19081
 

--- a/src/search_ann_benchmark/engines/weaviate.py
+++ b/src/search_ann_benchmark/engines/weaviate.py
@@ -22,7 +22,7 @@ class WeaviateConfig(EngineConfig):
     name: str = "weaviate"
     host: str = "localhost"
     port: int = 8091
-    version: str = "1.28.2"
+    version: str = "1.35.1"
     container_name: str = "benchmark_weaviate"
 
 


### PR DESCRIPTION
- Elasticsearch: 8.17.4 → 8.17.8 (security/bug fixes)
- Qdrant: 1.13.6 → 1.16.2 (performance improvements)
- Vespa: 8.499.20 → 8.596.20 (weekly release)
- Milvus: 2.5.4 → 2.6.7 (new features, mixCoord consolidation)
- OpenSearch: 2.19.1 → 2.19.4 (security/bug fixes)
- Weaviate: 1.28.2 → 1.35.1 (new vectorizer/reranker modules)
- pgvector: 0.8.0-pg17 → 0.8.1-pg17 (bug fixes)
- Chroma: 1.4.0 (already latest)

No implementation changes required as all engines maintain backward-compatible REST/API interfaces.