### PR TITLE
Upgrade OpenSearch to 3.4.0

### DIFF
--- a/.github/workflows/run-elasticsearch-bbq-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-linux.yml
@@ -24,7 +24,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "8.17.4"
+  ENGINE_VERSION: "9.2.3"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-int4-linux.yml
+++ b/.github/workflows/run-elasticsearch-int4-linux.yml
@@ -24,7 +24,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "8.17.4"
+  ENGINE_VERSION: "9.2.3"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-int8-linux.yml
+++ b/.github/workflows/run-elasticsearch-int8-linux.yml
@@ -24,7 +24,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "8.17.4"
+  ENGINE_VERSION: "9.2.3"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-linux.yml
+++ b/.github/workflows/run-elasticsearch-linux.yml
@@ -34,7 +34,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "8.17.4"
+  ENGINE_VERSION: "9.2.3"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-opensearch-faiss-linux.yml
+++ b/.github/workflows/run-opensearch-faiss-linux.yml
@@ -24,7 +24,7 @@ on:
 
 env:
   ENGINE_NAME: opensearch
-  ENGINE_VERSION: "2.19.1"
+  ENGINE_VERSION: "3.4.0"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-opensearch-linux.yml
+++ b/.github/workflows/run-opensearch-linux.yml
@@ -32,7 +32,7 @@ on:
 
 env:
   ENGINE_NAME: opensearch
-  ENGINE_VERSION: "2.19.1"
+  ENGINE_VERSION: "3.4.0"
 
 jobs:
   benchmark:

--- a/src/search_ann_benchmark/engines/elasticsearch.py
+++ b/src/search_ann_benchmark/engines/elasticsearch.py
@@ -22,7 +22,7 @@ class ElasticsearchConfig(EngineConfig):
     name: str = "elasticsearch"
     host: str = "localhost"
     port: int = 9211
-    version: str = "8.17.8"
+    version: str = "9.2.3"
     container_name: str = "benchmark_es"
     heap: str = "2g"
 


### PR DESCRIPTION
- Update default version from 2.19.4 to 3.4.0
- Remove deprecated index.knn.algo_param.ef_search setting from index configuration
  (removed in OpenSearch 3.0)
- Add ef_search as method_parameters in search query for FAISS engine
  (Lucene engine ignores ef_search and dynamically uses k value)
- Update GitHub Actions workflow versions