### PR TITLE
Add filter search functionality to Chroma

### DIFF
--- a/.github/workflows/run-chroma-linux.yml
+++ b/.github/workflows/run-chroma-linux.yml
@@ -64,8 +64,7 @@ jobs:
         run: |
           uv run search-ann-benchmark run ${ENGINE_NAME} \
             --target ${TARGET_CONFIG} \
-            --version ${ENGINE_VERSION} \
-            --no-filter
+            --version ${ENGINE_VERSION}
 
       - name: Upload results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Remove --no-filter flag from Chroma workflow to enable filtered search benchmarking. The filter search implementation already exists in the Chroma engine (_build_filter_query and search methods), this change activates it in CI like other search engines (Qdrant, etc).