### PR TITLE
ci(workflows): Expand path triggers to include core benchmark code

### DIFF
--- a/.github/workflows/run-chroma-linux.yml
+++ b/.github/workflows/run-chroma-linux.yml
@@ -5,11 +5,26 @@ on:
     branches:
       - main
     paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/chroma.py'
       - '.github/workflows/run-chroma-linux.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/chroma.py'
+      - '.github/workflows/run-chroma-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:

--- a/.github/workflows/run-clickhouse-linux.yml
+++ b/.github/workflows/run-clickhouse-linux.yml
@@ -5,11 +5,26 @@ on:
     branches:
       - main
     paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/clickhouse.py'
       - '.github/workflows/run-clickhouse-linux.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/clickhouse.py'
+      - '.github/workflows/run-clickhouse-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:

--- a/.github/workflows/run-elasticsearch-bbq-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-linux.yml
@@ -5,11 +5,26 @@ on:
     branches:
       - main
     paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/elasticsearch.py'
       - '.github/workflows/run-elasticsearch-bbq-linux.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/elasticsearch.py'
+      - '.github/workflows/run-elasticsearch-bbq-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:

--- a/.github/workflows/run-elasticsearch-int4-linux.yml
+++ b/.github/workflows/run-elasticsearch-int4-linux.yml
@@ -5,11 +5,26 @@ on:
     branches:
       - main
     paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/elasticsearch.py'
       - '.github/workflows/run-elasticsearch-int4-linux.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/elasticsearch.py'
+      - '.github/workflows/run-elasticsearch-int4-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:

--- a/.github/workflows/run-elasticsearch-int8-linux.yml
+++ b/.github/workflows/run-elasticsearch-int8-linux.yml
@@ -5,11 +5,26 @@ on:
     branches:
       - main
     paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/elasticsearch.py'
       - '.github/workflows/run-elasticsearch-int8-linux.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/elasticsearch.py'
+      - '.github/workflows/run-elasticsearch-int8-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:

--- a/.github/workflows/run-elasticsearch-linux.yml
+++ b/.github/workflows/run-elasticsearch-linux.yml
@@ -5,11 +5,26 @@ on:
     branches:
       - main
     paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/elasticsearch.py'
       - '.github/workflows/run-elasticsearch-linux.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/elasticsearch.py'
+      - '.github/workflows/run-elasticsearch-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:

--- a/.github/workflows/run-lancedb-linux.yml
+++ b/.github/workflows/run-lancedb-linux.yml
@@ -5,11 +5,26 @@ on:
     branches:
       - main
     paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/lancedb.py'
       - '.github/workflows/run-lancedb-linux.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/lancedb.py'
+      - '.github/workflows/run-lancedb-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:

--- a/.github/workflows/run-milvus-linux.yml
+++ b/.github/workflows/run-milvus-linux.yml
@@ -5,11 +5,26 @@ on:
     branches:
       - main
     paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/milvus.py'
       - '.github/workflows/run-milvus-linux.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/milvus.py'
+      - '.github/workflows/run-milvus-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:

--- a/.github/workflows/run-opensearch-faiss-linux.yml
+++ b/.github/workflows/run-opensearch-faiss-linux.yml
@@ -5,11 +5,26 @@ on:
     branches:
       - main
     paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/opensearch.py'
       - '.github/workflows/run-opensearch-faiss-linux.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/opensearch.py'
+      - '.github/workflows/run-opensearch-faiss-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:

--- a/.github/workflows/run-opensearch-linux.yml
+++ b/.github/workflows/run-opensearch-linux.yml
@@ -5,11 +5,26 @@ on:
     branches:
       - main
     paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/opensearch.py'
       - '.github/workflows/run-opensearch-linux.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/opensearch.py'
+      - '.github/workflows/run-opensearch-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:

--- a/.github/workflows/run-pgvector-linux.yml
+++ b/.github/workflows/run-pgvector-linux.yml
@@ -5,11 +5,26 @@ on:
     branches:
       - main
     paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/pgvector.py'
       - '.github/workflows/run-pgvector-linux.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/pgvector.py'
+      - '.github/workflows/run-pgvector-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:

--- a/.github/workflows/run-qdrant-int8-linux.yml
+++ b/.github/workflows/run-qdrant-int8-linux.yml
@@ -5,11 +5,26 @@ on:
     branches:
       - main
     paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/qdrant.py'
       - '.github/workflows/run-qdrant-int8-linux.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/qdrant.py'
+      - '.github/workflows/run-qdrant-int8-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:

--- a/.github/workflows/run-qdrant-linux.yml
+++ b/.github/workflows/run-qdrant-linux.yml
@@ -5,11 +5,26 @@ on:
     branches:
       - main
     paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/qdrant.py'
       - '.github/workflows/run-qdrant-linux.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/qdrant.py'
+      - '.github/workflows/run-qdrant-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:

--- a/.github/workflows/run-redisstack-linux.yml
+++ b/.github/workflows/run-redisstack-linux.yml
@@ -5,11 +5,26 @@ on:
     branches:
       - main
     paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/redisstack.py'
       - '.github/workflows/run-redisstack-linux.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/redisstack.py'
+      - '.github/workflows/run-redisstack-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:

--- a/.github/workflows/run-vald-linux.yml
+++ b/.github/workflows/run-vald-linux.yml
@@ -5,11 +5,26 @@ on:
     branches:
       - main
     paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/vald.py'
       - '.github/workflows/run-vald-linux.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/vald.py'
+      - '.github/workflows/run-vald-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:

--- a/.github/workflows/run-vespa-linux.yml
+++ b/.github/workflows/run-vespa-linux.yml
@@ -5,11 +5,26 @@ on:
     branches:
       - main
     paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/vespa.py'
       - '.github/workflows/run-vespa-linux.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/vespa.py'
+      - '.github/workflows/run-vespa-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:

--- a/.github/workflows/run-weaviate-linux.yml
+++ b/.github/workflows/run-weaviate-linux.yml
@@ -5,11 +5,26 @@ on:
     branches:
       - main
     paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/weaviate.py'
       - '.github/workflows/run-weaviate-linux.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/weaviate.py'
+      - '.github/workflows/run-weaviate-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:


### PR DESCRIPTION
## Summary

This PR updates all 17 engine benchmark workflows to trigger not only on engine-specific file changes, but also when core benchmark framework code is modified.

## Changes Made

Added the following path triggers to both `push` and `pull_request` events in all engine workflow files:

- `src/search_ann_benchmark/__init__.py`
- `src/search_ann_benchmark/cli.py`
- `src/search_ann_benchmark/config.py`
- `src/search_ann_benchmark/runner.py`
- `src/search_ann_benchmark/core/**`
- `src/search_ann_benchmark/engines/__init__.py`

### Affected workflows:
- Chroma
- ClickHouse
- Elasticsearch (standard, BBQ, int4, int8)
- LanceDB
- Milvus
- OpenSearch (standard, FAISS)
- pgvector
- Qdrant (standard, int8)
- Redis Stack
- Vald
- Vespa
- Weaviate

## Motivation

Previously, workflows only triggered when their specific engine implementation file or workflow file changed. This meant that changes to core modules (CLI, config, runner, metrics, base class, etc.) would not re-run benchmarks, potentially missing regressions or inconsistencies introduced by framework changes.

With this update, any modification to the shared benchmark infrastructure will trigger all engine workflows, ensuring benchmark results remain valid after core code changes.

## Testing

- Verified workflow YAML syntax is valid
- Path patterns follow existing conventions