### PR TITLE
Fix pgvector filtered search precision issues

### DIFF
--- a/src/search_ann_benchmark/engines/pgvector.py
+++ b/src/search_ann_benchmark/engines/pgvector.py
@@ -121,7 +121,7 @@ class PgvectorEngine(VectorSearchEngine):
                     doc_id integer PRIMARY KEY,
                     page_id integer,
                     rev_id integer,
-                    section character(128),
+                    section text,
                     embedding {vector_type}({cfg.dimension})
                 );
             """)


### PR DESCRIPTION
The fixed-length CHAR(128) type was causing filtered search to fail because PostgreSQL pads CHAR values with spaces. When searching with WHERE section = 'History', it wouldn't match the stored value
'History                    ...' (padded to 128 chars).

Using TEXT type (variable-length) fixes this issue by storing values without padding, allowing proper equality comparisons in filtered searches.

This improves Precision@10 for filtered search benchmarks.