### PR TITLE
feat(vald): Enable filtered search evaluation using post-filtering

### DIFF
--- a/.github/workflows/run-vald-linux.yml
+++ b/.github/workflows/run-vald-linux.yml
@@ -77,7 +77,7 @@ jobs:
         env:
           TARGET_CONFIG: ${{ github.event.inputs.target_config || '100k-768-m32-efc200-ef100-ip' }}
         run: |
-          ARGS="--target ${TARGET_CONFIG} --version ${ENGINE_VERSION} --no-filter"
+          ARGS="--target ${TARGET_CONFIG} --version ${ENGINE_VERSION}"
           uv run search-ann-benchmark run ${ENGINE_NAME} ${ARGS}
 
       - name: Upload results


### PR DESCRIPTION
Vald NGT does not support native filtering, so we implement post-filtering:
- Store section metadata in-memory during document insertion
- When filtering is requested, fetch more candidates (top_k * multiplier)
- Apply post-filtering to match target section
- Return only the requested top_k results

Also removes --no-filter flag from workflow to enable filtered benchmarks.