### PR TITLE
Fix lancedb filtered search in GitHub Actions

### DIFF
--- a/.github/workflows/run-lancedb-linux.yml
+++ b/.github/workflows/run-lancedb-linux.yml
@@ -79,8 +79,7 @@ jobs:
         run: |
           uv run search-ann-benchmark run ${ENGINE_NAME} \
             --target ${TARGET_CONFIG} \
-            --version ${ENGINE_VERSION} \
-            --no-filter
+            --version ${ENGINE_VERSION}
 
       - name: Upload results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Remove --no-filter flag to run filtered search evaluation. LanceDB engine already supports filtered search with fetch multiplier.