### PR TITLE
Add DiskBBQ performance testing for Elasticsearch 9.2

### DIFF
--- a/.github/workflows/run-elasticsearch-bbq-disk-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-disk-linux.yml
@@ -1,0 +1,91 @@
+name: Run Elasticsearch (bbq_disk) benchmark on Linux
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/elasticsearch.py'
+      - '.github/workflows/run-elasticsearch-bbq-disk-linux.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'src/search_ann_benchmark/__init__.py'
+      - 'src/search_ann_benchmark/cli.py'
+      - 'src/search_ann_benchmark/config.py'
+      - 'src/search_ann_benchmark/runner.py'
+      - 'src/search_ann_benchmark/core/**'
+      - 'src/search_ann_benchmark/engines/__init__.py'
+      - 'src/search_ann_benchmark/engines/elasticsearch.py'
+      - '.github/workflows/run-elasticsearch-bbq-disk-linux.yml'
+  workflow_dispatch:
+    inputs:
+      target_config:
+        description: 'Target configuration'
+        required: false
+        default: '100k-768-m32-efc200-ef100-ip'
+        type: choice
+        options:
+          - 100k-768-m32-efc200-ef100-ip
+          - 1m-768-m48-efc200-ef100-ip
+          - 5m-768-m48-efc200-ef100-ip
+
+env:
+  ENGINE_NAME: elasticsearch
+  ENGINE_VERSION: "9.2.3"
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Report Hardware
+        run: bash scripts/get_hardware_info.sh
+
+      - name: Cache dataset
+        uses: actions/cache@v4
+        with:
+          path: dataset
+          key: ${{ runner.os }}-dataset-gha-v1
+
+      - name: Download dataset
+        run: bash scripts/setup.sh gha
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run benchmark
+        env:
+          TARGET_CONFIG: ${{ github.event.inputs.target_config || '100k-768-m32-efc200-ef100-ip' }}
+          PRODUCT_VARIANT: "bbq_disk"
+        run: |
+          uv run search-ann-benchmark run ${ENGINE_NAME} \
+            --target ${TARGET_CONFIG} \
+            --version ${ENGINE_VERSION} \
+            --quantization bbq_disk \
+            --variant bbq_disk
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: elasticsearch-bbq-disk-results
+          path: results.json

--- a/src/search_ann_benchmark/cli.py
+++ b/src/search_ann_benchmark/cli.py
@@ -40,7 +40,7 @@ def main() -> None:
 @click.option(
     "--quantization",
     default=None,
-    type=click.Choice(["none", "int4", "int8", "bbq", "pq", "byte", "halfvec"]),
+    type=click.Choice(["none", "int4", "int8", "bbq", "bbq_disk", "pq", "byte", "halfvec"]),
     help="Quantization mode",
 )
 @click.option(

--- a/src/search_ann_benchmark/engines/elasticsearch.py
+++ b/src/search_ann_benchmark/engines/elasticsearch.py
@@ -100,6 +100,8 @@ class ElasticsearchEngine(VectorSearchEngine):
             return "int4_hnsw"
         elif cfg.quantization == "bbq":
             return "bbq_hnsw"
+        elif cfg.quantization == "bbq_disk":
+            return "bbq_disk"
         return "hnsw"
 
     def create_index(self, number_of_shards: int = 1, number_of_replicas: int = 0) -> None:

--- a/src/search_ann_benchmark/engines/elasticsearch.py
+++ b/src/search_ann_benchmark/engines/elasticsearch.py
@@ -109,6 +109,13 @@ class ElasticsearchEngine(VectorSearchEngine):
         knn_type = self._get_knn_type()
         logger.info(f"Creating index {cfg.index_name} with {knn_type}...")
 
+        # Build index_options based on knn_type
+        # bbq_disk does not support HNSW parameters (m, ef_construction)
+        index_options: dict[str, Any] = {"type": knn_type}
+        if knn_type != "bbq_disk":
+            index_options["m"] = cfg.hnsw_m
+            index_options["ef_construction"] = cfg.hnsw_ef_construction
+
         response = requests.put(
             f"{self.base_url}/{cfg.index_name}",
             headers={"Content-Type": "application/json"},
@@ -126,11 +133,7 @@ class ElasticsearchEngine(VectorSearchEngine):
                             "dims": cfg.dimension,
                             "index": True,
                             "similarity": cfg.distance,
-                            "index_options": {
-                                "type": knn_type,
-                                "m": cfg.hnsw_m,
-                                "ef_construction": cfg.hnsw_ef_construction,
-                            },
+                            "index_options": index_options,
                         },
                     },
                 },


### PR DESCRIPTION
Elasticsearch 9.2 introduced bbq_disk index type for disk-based BBQ quantization. This adds support for benchmarking this new index type.

Changes:
- Add bbq_disk quantization option to CLI
- Update _get_knn_type() to return bbq_disk index type
- Create dedicated GitHub Actions workflow for bbq_disk benchmarks