### PR TITLE
chore: Bump engine versions for Chroma, Elasticsearch, LanceDB, Milvus, Qdrant, and Vespa

### DIFF
--- a/.github/workflows/run-chroma-linux.yml
+++ b/.github/workflows/run-chroma-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: chroma
-  ENGINE_VERSION: "1.4.0"
+  ENGINE_VERSION: "1.4.1"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-bbq-disk-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-disk-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.2.3"
+  ENGINE_VERSION: "9.2.4"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-bbq-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.2.3"
+  ENGINE_VERSION: "9.2.4"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-int4-linux.yml
+++ b/.github/workflows/run-elasticsearch-int4-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.2.3"
+  ENGINE_VERSION: "9.2.4"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-int8-linux.yml
+++ b/.github/workflows/run-elasticsearch-int8-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.2.3"
+  ENGINE_VERSION: "9.2.4"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-linux.yml
+++ b/.github/workflows/run-elasticsearch-linux.yml
@@ -49,7 +49,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.2.3"
+  ENGINE_VERSION: "9.2.4"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-lancedb-linux.yml
+++ b/.github/workflows/run-lancedb-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: lancedb
-  ENGINE_VERSION: "0.26.0"
+  ENGINE_VERSION: "0.26.1"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-milvus-linux.yml
+++ b/.github/workflows/run-milvus-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: milvus
-  ENGINE_VERSION: "2.6.7"
+  ENGINE_VERSION: "2.6.9"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-qdrant-int8-linux.yml
+++ b/.github/workflows/run-qdrant-int8-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: qdrant
-  ENGINE_VERSION: "1.16.2"
+  ENGINE_VERSION: "1.16.3"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-qdrant-linux.yml
+++ b/.github/workflows/run-qdrant-linux.yml
@@ -47,7 +47,7 @@ on:
 
 env:
   ENGINE_NAME: qdrant
-  ENGINE_VERSION: "1.16.2"
+  ENGINE_VERSION: "1.16.3"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-vespa-linux.yml
+++ b/.github/workflows/run-vespa-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: vespa
-  ENGINE_VERSION: "8.620.35"
+  ENGINE_VERSION: "8.631.39"
 
 jobs:
   benchmark:

--- a/src/search_ann_benchmark/engines/chroma.py
+++ b/src/search_ann_benchmark/engines/chroma.py
@@ -21,7 +21,7 @@ class ChromaConfig(EngineConfig):
     name: str = "chroma"
     host: str = "localhost"
     port: int = 8008
-    version: str = "1.4.0"
+    version: str = "1.4.1"
     container_name: str = "benchmark_chroma"
 
 

--- a/src/search_ann_benchmark/engines/elasticsearch.py
+++ b/src/search_ann_benchmark/engines/elasticsearch.py
@@ -22,7 +22,7 @@ class ElasticsearchConfig(EngineConfig):
     name: str = "elasticsearch"
     host: str = "localhost"
     port: int = 9211
-    version: str = "9.2.3"
+    version: str = "9.2.4"
     container_name: str = "benchmark_es"
     heap: str = "2g"
 

--- a/src/search_ann_benchmark/engines/lancedb.py
+++ b/src/search_ann_benchmark/engines/lancedb.py
@@ -23,7 +23,7 @@ class LancedbConfig(EngineConfig):
     name: str = "lancedb"
     host: str = "localhost"
     port: int = 0  # Not used for embedded database
-    version: str = "0.26.0"
+    version: str = "0.26.1"
     container_name: str = ""  # Not used for embedded database
     db_path: str = ".lancedb"
     # Fetch multiplier for filtered search - fetch more candidates before filtering

--- a/src/search_ann_benchmark/engines/milvus.py
+++ b/src/search_ann_benchmark/engines/milvus.py
@@ -24,7 +24,7 @@ class MilvusConfig(EngineConfig):
     name: str = "milvus"
     host: str = "localhost"
     port: int = 19540
-    version: str = "2.6.7"
+    version: str = "2.6.9"
     container_name: str = "benchmark_milvus"
     etcd_version: str = "3.5.5"
     minio_version: str = "RELEASE.2023-03-20T20-16-18Z"

--- a/src/search_ann_benchmark/engines/qdrant.py
+++ b/src/search_ann_benchmark/engines/qdrant.py
@@ -22,7 +22,7 @@ class QdrantConfig(EngineConfig):
     name: str = "qdrant"
     host: str = "localhost"
     port: int = 6344
-    version: str = "1.16.2"
+    version: str = "1.16.3"
     container_name: str = "benchmark_qdrant"
 
 

--- a/src/search_ann_benchmark/engines/vespa.py
+++ b/src/search_ann_benchmark/engines/vespa.py
@@ -30,7 +30,7 @@ class VespaConfig(EngineConfig):
     name: str = "vespa"
     host: str = "localhost"
     port: int = 8090
-    version: str = "8.620.35"
+    version: str = "8.631.39"
     container_name: str = "benchmark_vespa"
     management_port: int = 19081
 


### PR DESCRIPTION
## Summary
- Update engine versions across all workflow files and Python engine configs to latest releases

## Changes Made
| Engine | Previous | Updated |
|--------|----------|---------|
| Chroma | 1.4.0 | 1.4.1 |
| Elasticsearch | 9.2.3 | 9.2.4 |
| LanceDB | 0.26.0 | 0.26.1 |
| Milvus | 2.6.7 | 2.6.9 |
| Qdrant | 1.16.2 | 1.16.3 |
| Vespa | 8.620.35 | 8.631.39 |

## Testing
- CI workflows will validate that benchmarks run successfully with the updated versions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)