### PR TITLE
chore(opensearch): bump version from 3.4.0 to 3.5.0

### DIFF
--- a/.github/workflows/run-opensearch-faiss-linux.yml
+++ b/.github/workflows/run-opensearch-faiss-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: opensearch
-  ENGINE_VERSION: "3.4.0"
+  ENGINE_VERSION: "3.5.0"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-opensearch-linux.yml
+++ b/.github/workflows/run-opensearch-linux.yml
@@ -47,7 +47,7 @@ on:
 
 env:
   ENGINE_NAME: opensearch
-  ENGINE_VERSION: "3.4.0"
+  ENGINE_VERSION: "3.5.0"
 
 jobs:
   benchmark:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This benchmarking suite aims to provide an empirical basis for comparing the per
 |--------|---------|----------------|
 | Qdrant | 1.16.2 | [![Run Qdrant](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml) |
 | Elasticsearch | 9.2.3 | [![Run Elasticsearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml) |
-| OpenSearch | 3.4.0 | [![Run OpenSearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml) |
+| OpenSearch | 3.5.0 | [![Run OpenSearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml) |
 | Milvus | 2.6.7 | [![Run Milvus](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml) |
 | Weaviate | 1.35.2 | [![Run Weaviate](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-weaviate-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-weaviate-linux.yml) |
 | Vespa | 8.620.35 | [![Run Vespa](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-vespa-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-vespa-linux.yml) |

--- a/src/search_ann_benchmark/engines/opensearch.py
+++ b/src/search_ann_benchmark/engines/opensearch.py
@@ -23,7 +23,7 @@ class OpenSearchConfig(EngineConfig):
     name: str = "opensearch"
     host: str = "localhost"
     port: int = 9212
-    version: str = "3.4.0"
+    version: str = "3.5.0"
     container_name: str = "benchmark_opensearch"
     heap: str = "2g"
     engine: str = "lucene"  # or "faiss"


### PR DESCRIPTION
## Summary

Bumps OpenSearch engine version from 3.4.0 to 3.5.0 to keep the benchmark suite up to date with the latest release.

## Changes Made

- Updated `ENGINE_VERSION` in `.github/workflows/run-opensearch-linux.yml` from `3.4.0` to `3.5.0`
- Updated `ENGINE_VERSION` in `.github/workflows/run-opensearch-faiss-linux.yml` from `3.4.0` to `3.5.0`
- Updated `version` default value in `src/search_ann_benchmark/engines/opensearch.py` from `3.4.0` to `3.5.0`
- Updated OpenSearch version entry in `README.md` from `3.4.0` to `3.5.0`

## Testing

The GitHub Actions workflows will automatically run the benchmark tests against OpenSearch 3.5.0 to validate compatibility.

## Additional Notes

This is a routine version bump to track the latest OpenSearch release. No behavioral changes are expected.