### PR TITLE
chore(elasticsearch): bump version from 9.2.4 to 9.3.1

### DIFF
--- a/.github/workflows/run-elasticsearch-bbq-disk-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-disk-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.2.4"
+  ENGINE_VERSION: "9.3.1"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-bbq-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.2.4"
+  ENGINE_VERSION: "9.3.1"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-int4-linux.yml
+++ b/.github/workflows/run-elasticsearch-int4-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.2.4"
+  ENGINE_VERSION: "9.3.1"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-int8-linux.yml
+++ b/.github/workflows/run-elasticsearch-int8-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.2.4"
+  ENGINE_VERSION: "9.3.1"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-linux.yml
+++ b/.github/workflows/run-elasticsearch-linux.yml
@@ -49,7 +49,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.2.4"
+  ENGINE_VERSION: "9.3.1"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-opensearch-faiss-linux.yml
+++ b/.github/workflows/run-opensearch-faiss-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: opensearch
-  ENGINE_VERSION: "3.4.0"
+  ENGINE_VERSION: "3.5.0"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-opensearch-linux.yml
+++ b/.github/workflows/run-opensearch-linux.yml
@@ -47,7 +47,7 @@ on:
 
 env:
   ENGINE_NAME: opensearch
-  ENGINE_VERSION: "3.4.0"
+  ENGINE_VERSION: "3.5.0"
 
 jobs:
   benchmark:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This benchmarking suite aims to provide an empirical basis for comparing the per
 |--------|---------|----------------|
 | Qdrant | 1.16.2 | [![Run Qdrant](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml) |
 | Elasticsearch | 9.2.3 | [![Run Elasticsearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml) |
-| OpenSearch | 3.4.0 | [![Run OpenSearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml) |
+| OpenSearch | 3.5.0 | [![Run OpenSearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml) |
 | Milvus | 2.6.7 | [![Run Milvus](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml) |
 | Weaviate | 1.35.2 | [![Run Weaviate](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-weaviate-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-weaviate-linux.yml) |
 | Vespa | 8.620.35 | [![Run Vespa](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-vespa-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-vespa-linux.yml) |

--- a/src/search_ann_benchmark/engines/elasticsearch.py
+++ b/src/search_ann_benchmark/engines/elasticsearch.py
@@ -22,7 +22,7 @@ class ElasticsearchConfig(EngineConfig):
     name: str = "elasticsearch"
     host: str = "localhost"
     port: int = 9211
-    version: str = "9.2.4"
+    version: str = "9.3.1"
     container_name: str = "benchmark_es"
     heap: str = "2g"
 

--- a/src/search_ann_benchmark/engines/opensearch.py
+++ b/src/search_ann_benchmark/engines/opensearch.py
@@ -23,7 +23,7 @@ class OpenSearchConfig(EngineConfig):
     name: str = "opensearch"
     host: str = "localhost"
     port: int = 9212
-    version: str = "3.4.0"
+    version: str = "3.5.0"
     container_name: str = "benchmark_opensearch"
     heap: str = "2g"
     engine: str = "lucene"  # or "faiss"


### PR DESCRIPTION
## Summary

Bumps the Elasticsearch engine version from 9.2.4 to 9.3.1 to stay current with the latest release.

## Changes Made

- Updated `ENGINE_VERSION` env var in all 5 Elasticsearch GitHub Actions workflows:
  - `run-elasticsearch-linux.yml`
  - `run-elasticsearch-int8-linux.yml`
  - `run-elasticsearch-int4-linux.yml`
  - `run-elasticsearch-bbq-linux.yml`
  - `run-elasticsearch-bbq-disk-linux.yml`
- Updated default `version` in `ElasticsearchConfig` in `src/search_ann_benchmark/engines/elasticsearch.py`

## Testing

CI workflows will run the benchmarks against Elasticsearch 9.3.1 to validate compatibility.

## Additional Notes

This is a routine version bump following the same pattern as previous engine version updates in this repo.