### PR TITLE
chore(qdrant): bump version to 1.17.0

### DIFF
--- a/.github/workflows/run-qdrant-int8-linux.yml
+++ b/.github/workflows/run-qdrant-int8-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: qdrant
-  ENGINE_VERSION: "1.16.3"
+  ENGINE_VERSION: "1.17.0"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-qdrant-linux.yml
+++ b/.github/workflows/run-qdrant-linux.yml
@@ -47,7 +47,7 @@ on:
 
 env:
   ENGINE_NAME: qdrant
-  ENGINE_VERSION: "1.16.3"
+  ENGINE_VERSION: "1.17.0"
 
 jobs:
   benchmark:

--- a/src/search_ann_benchmark/engines/qdrant.py
+++ b/src/search_ann_benchmark/engines/qdrant.py
@@ -22,7 +22,7 @@ class QdrantConfig(EngineConfig):
     name: str = "qdrant"
     host: str = "localhost"
     port: int = 6344
-    version: str = "1.16.3"
+    version: str = "1.17.0"
     container_name: str = "benchmark_qdrant"
 
 


### PR DESCRIPTION
## Summary

Bumps Qdrant engine version from 1.16.3 to 1.17.0.

## Changes Made

- Updated `ENGINE_VERSION` in `.github/workflows/run-qdrant-linux.yml` to `1.17.0`
- Updated `ENGINE_VERSION` in `.github/workflows/run-qdrant-int8-linux.yml` to `1.17.0`
- Updated default `version` in `QdrantConfig` in `src/search_ann_benchmark/engines/qdrant.py` to `1.17.0`

## Testing

The GitHub Actions workflows will automatically run benchmarks with the new Qdrant version to validate compatibility and collect updated performance metrics.

## Breaking Changes

None.

## Additional Notes

This keeps the benchmark suite aligned with the latest Qdrant release.