### PR TITLE
chore(clickhouse): bump ClickHouse version from 25.8 to 26.2

### DIFF
--- a/.github/workflows/run-clickhouse-linux.yml
+++ b/.github/workflows/run-clickhouse-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: clickhouse
-  ENGINE_VERSION: "25.8"
+  ENGINE_VERSION: "26.2"
 
 jobs:
   benchmark:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This benchmarking suite aims to provide an empirical basis for comparing the per
 | Chroma | 1.5.2 | [![Run Chroma](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-chroma-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-chroma-linux.yml) |
 | Redis Stack | 7.4.0-v8 | [![Run Redis Stack](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-redisstack-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-redisstack-linux.yml) |
 | Vald | v1.7.17 | [![Run Vald](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-vald-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-vald-linux.yml) |
-| ClickHouse | 25.8 | [![Run ClickHouse](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-clickhouse-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-clickhouse-linux.yml) |
+| ClickHouse | 26.2 | [![Run ClickHouse](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-clickhouse-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-clickhouse-linux.yml) |
 | LanceDB | 0.26.0 | [![Run LanceDB](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-lancedb-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-lancedb-linux.yml) |
 
 ## Prerequisites

--- a/src/search_ann_benchmark/engines/clickhouse.py
+++ b/src/search_ann_benchmark/engines/clickhouse.py
@@ -22,7 +22,7 @@ class ClickHouseConfig(EngineConfig):
     name: str = "clickhouse"
     host: str = "localhost"
     port: int = 8123
-    version: str = "25.8"
+    version: str = "26.2"
     container_name: str = "benchmark_clickhouse"
     database: str = "default"
 


### PR DESCRIPTION
## Summary
- Bump ClickHouse version from 25.8 to 26.2 (latest stable: v26.2.4.23-stable)
- Updated version in Python config, GitHub Actions workflow, and README.md

## Changes
- `src/search_ann_benchmark/engines/clickhouse.py`: version `25.8` → `26.2`
- `.github/workflows/run-clickhouse-linux.yml`: ENGINE_VERSION `25.8` → `26.2`
- `README.md`: Supported Engines table `25.8` → `26.2`

## Release Notes (25.8 → 26.2)
- QBit data type promoted from experimental to GA (quantized bit-packed vector storage)
- Distributed vector search across cluster replicas
- No breaking changes detected for vector_similarity, HNSW, or distance functions

## Test plan
- [ ] CI workflow passes with ClickHouse 26.2 Docker image
- [ ] Benchmark notebook executes successfully
- [ ] Performance metrics are collected correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)