### PR TITLE
fix(elasticsearch): force merge index for bbq_disk knn type

### DIFF
--- a/src/search_ann_benchmark/engines/elasticsearch.py
+++ b/src/search_ann_benchmark/engines/elasticsearch.py
@@ -357,6 +357,11 @@ class ElasticsearchEngine(VectorSearchEngine):
         """Wait for indexing to complete using flush/close/open/refresh cycle."""
         logger.debug("Starting indexing complete sequence (flush/close/open/refresh)")
         self.flush_index()
+
+        # bbq_disk requires force merge to a single segment for disk-based search to work
+        if self._get_knn_type() == "bbq_disk":
+            self.forcemerge_index()
+
         self.close_index()
 
         # Wait for index to be closed (poll instead of fixed sleep)


### PR DESCRIPTION
## Summary

Adds a force merge step when the knn type is `bbq_disk` during the indexing completion sequence in the Elasticsearch engine.

## Changes Made

- In `wait_for_indexing_complete`, call `forcemerge_index()` before closing the index when `_get_knn_type()` returns `"bbq_disk"`

## Testing

- The `bbq_disk` variant should now complete indexing correctly and produce valid search results

## Breaking Changes

- None

## Additional Notes

`bbq_disk` (Binary Block Quantization with disk-based storage) requires the index to be merged into a single segment before disk-based vector search can function properly. Without this merge, queries may fail or return incorrect results.