### PR TITLE
chore(readme): bump Qdrant to 1.17.0 and Elasticsearch to 9.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This benchmarking suite aims to provide an empirical basis for comparing the per
 
 | Engine | Version | GitHub Actions |
 |--------|---------|----------------|
-| Qdrant | 1.16.2 | [![Run Qdrant](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml) |
-| Elasticsearch | 9.2.3 | [![Run Elasticsearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml) |
+| Qdrant | 1.17.0 | [![Run Qdrant](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml) |
+| Elasticsearch | 9.3.1 | [![Run Elasticsearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml) |
 | OpenSearch | 3.5.0 | [![Run OpenSearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml) |
 | Milvus | 2.6.11 | [![Run Milvus](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml) |
 | Weaviate | 1.36.2 | [![Run Weaviate](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-weaviate-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-weaviate-linux.yml) |


### PR DESCRIPTION
## Summary

Update version numbers in README.md for Qdrant and Elasticsearch to reflect their latest releases.

## Changes Made

- Bump Qdrant version from 1.16.2 to 1.17.0
- Bump Elasticsearch version from 9.2.3 to 9.3.1

## Testing

No functional changes — README update only. CI badges remain valid as they reference workflow files, not version numbers.

## Additional Notes

This is a documentation-only change to keep the README version table current with the latest engine releases.