### PR TITLE
fix(pgvector): improve filtered ANN search precision with iterative scan

### DIFF
--- a/src/search_ann_benchmark/engines/pgvector.py
+++ b/src/search_ann_benchmark/engines/pgvector.py
@@ -147,6 +147,7 @@ class PgvectorEngine(VectorSearchEngine):
         start_time = time.time()
         with psycopg.connect(f"dbname={pg_cfg.dbname} {pg_cfg.conninfo}") as conn:
             conn.execute(create_idx)
+            conn.execute(f"CREATE INDEX ON {cfg.index_name} (section);")
         elapsed = time.time() - start_time
         print(f"[OK] {elapsed:.2f}s")
 
@@ -265,6 +266,8 @@ class PgvectorEngine(VectorSearchEngine):
             with conn.cursor() as cur:
                 cur.execute("BEGIN;")
                 cur.execute(f"SET LOCAL hnsw.ef_search = {cfg.hnsw_ef};")
+                if filter_query:
+                    cur.execute("SET LOCAL hnsw.iterative_scan = relaxed_order;")
                 cur.execute(query, tuple(params))
                 docs = cur.fetchall()
                 took_ms = (time.time() - start_time) * 1000


### PR DESCRIPTION
## Summary

pgvector 0.8.2-pg17 の Keyword Filtering 付き ANN Search で Precision@10 が 0.34 と極めて低い問題を修正する。

## Changes Made

- **`search()`**: フィルタクエリが存在する場合に `SET LOCAL hnsw.iterative_scan = relaxed_order;` を実行するよう追加。これにより HNSW グラフの探索がフィルタ条件を満たす k 件の結果が集まるまで継続される（pre-filtering 相当の動作）。`SET LOCAL` で現トランザクション内のみに適用し、フィルタなしクエリには影響しない。
- **`create_hnsw_index()`**: `section` カラムに B-tree インデックスを追加。PostgreSQL のクエリプランナがフィルタの選択性を正確に評価し、HNSW + WHERE の組み合わせで最適な実行計画を選択できるようにする。

## Root Cause

pgvector のデフォルト動作では SQL の `WHERE section = %s` が HNSW インデックススキャン後に適用される（post-filtering）。HNSW が返す上位 k 件の候補からフィルタで多数が除外されるため、結果数・精度ともに大幅に低下していた。`hnsw.iterative_scan` は pgvector 0.8.0 で導入されたオプションで、フィルタ条件を満たす結果が k 件揃うまで HNSW グラフ探索を継続させる。

## Testing

```bash
export TARGET_CONFIG=100k-768-m32-efc200-ef100-ip
uv run search-ann-benchmark run pgvector --target ${TARGET_CONFIG}
```

Expected: Filtered Precision@10 improves from ~0.34 to 0.90+, Unfiltered Precision@10 unchanged.

## Breaking Changes

None. `SET LOCAL` scopes the setting to the current transaction only, so no global state is changed.

## Additional Notes

- `relaxed_order` is preferred over `strict_order` — it reaches the same precision with lower overhead by not re-ranking the full result set.
- The B-tree index on `section` is created after bulk data insertion, consistent with the existing HNSW index creation pattern.