### PR TITLE
chore(qdrant): bump Qdrant version from 1.17.0 to 1.17.1

### DIFF
--- a/.github/workflows/run-qdrant-int8-linux.yml
+++ b/.github/workflows/run-qdrant-int8-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: qdrant
-  ENGINE_VERSION: "1.17.0"
+  ENGINE_VERSION: "1.17.1"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-qdrant-linux.yml
+++ b/.github/workflows/run-qdrant-linux.yml
@@ -47,7 +47,7 @@ on:
 
 env:
   ENGINE_NAME: qdrant
-  ENGINE_VERSION: "1.17.0"
+  ENGINE_VERSION: "1.17.1"
 
 jobs:
   benchmark:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This benchmarking suite aims to provide an empirical basis for comparing the per
 
 | Engine | Version | GitHub Actions |
 |--------|---------|----------------|
-| Qdrant | 1.17.0 | [![Run Qdrant](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml) |
+| Qdrant | 1.17.1 | [![Run Qdrant](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml) |
 | Elasticsearch | 9.3.1 | [![Run Elasticsearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml) |
 | OpenSearch | 3.5.0 | [![Run OpenSearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml) |
 | Milvus | 2.6.11 | [![Run Milvus](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml) |

--- a/src/search_ann_benchmark/engines/qdrant.py
+++ b/src/search_ann_benchmark/engines/qdrant.py
@@ -22,7 +22,7 @@ class QdrantConfig(EngineConfig):
     name: str = "qdrant"
     host: str = "localhost"
     port: int = 6344
-    version: str = "1.17.0"
+    version: str = "1.17.1"
     container_name: str = "benchmark_qdrant"
 
 


### PR DESCRIPTION
## Summary
- Bump Qdrant from 1.17.0 to 1.17.1 (patch release)
- v1.17.1 includes bug fixes for WAL reading/replay, cluster snapshot restoration, concurrent ingestion errors, and non-blocking Gridstore flushes to reduce search tail latencies
- No breaking API changes

## Test plan
- [ ] CI workflow `run-qdrant-linux.yml` passes
- [ ] CI workflow `run-qdrant-int8-linux.yml` passes