### PR TITLE
chore(elasticsearch): bump Elasticsearch version from 9.3.2 to 9.3.3

### DIFF
--- a/.github/workflows/run-elasticsearch-bbq-disk-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-disk-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.3.2"
+  ENGINE_VERSION: "9.3.3"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-bbq-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.3.2"
+  ENGINE_VERSION: "9.3.3"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-int4-linux.yml
+++ b/.github/workflows/run-elasticsearch-int4-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.3.2"
+  ENGINE_VERSION: "9.3.3"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-int8-linux.yml
+++ b/.github/workflows/run-elasticsearch-int8-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.3.2"
+  ENGINE_VERSION: "9.3.3"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-linux.yml
+++ b/.github/workflows/run-elasticsearch-linux.yml
@@ -49,7 +49,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.3.2"
+  ENGINE_VERSION: "9.3.3"
 
 jobs:
   benchmark:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This benchmarking suite aims to provide an empirical basis for comparing the per
 | Engine | Version | GitHub Actions |
 |--------|---------|----------------|
 | Qdrant | 1.17.1 | [![Run Qdrant](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml) |
-| Elasticsearch | 9.3.2 | [![Run Elasticsearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml) |
+| Elasticsearch | 9.3.3 | [![Run Elasticsearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml) |
 | OpenSearch | 3.5.0 | [![Run OpenSearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml) |
 | Milvus | 2.6.14 | [![Run Milvus](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml) |
 | Weaviate | 1.36.9 | [![Run Weaviate](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-weaviate-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-weaviate-linux.yml) |

--- a/src/search_ann_benchmark/engines/elasticsearch.py
+++ b/src/search_ann_benchmark/engines/elasticsearch.py
@@ -22,7 +22,7 @@ class ElasticsearchConfig(EngineConfig):
     name: str = "elasticsearch"
     host: str = "localhost"
     port: int = 9211
-    version: str = "9.3.2"
+    version: str = "9.3.3"
     container_name: str = "benchmark_es"
     heap: str = "2g"
 


### PR DESCRIPTION
## Summary
Bumps the Elasticsearch engine version from 9.3.2 to 9.3.3 across the benchmark suite and the documentation.

## Changes Made
- Update `ENGINE_VERSION` to `9.3.3` in all Elasticsearch GitHub Actions workflows:
  - `run-elasticsearch-linux.yml`
  - `run-elasticsearch-int8-linux.yml`
  - `run-elasticsearch-int4-linux.yml`
  - `run-elasticsearch-bbq-linux.yml`
  - `run-elasticsearch-bbq-disk-linux.yml`
- Update the default `version` in `ElasticsearchConfig` (`src/search_ann_benchmark/engines/elasticsearch.py`) to `9.3.3`
- Update the Elasticsearch version displayed in the engines table in `README.md`

## Testing
- Will be verified by the `run-elasticsearch-*-linux` GitHub Actions workflows on this PR.

## Breaking Changes
- None. This is a patch-level version bump of the Elasticsearch container.

## Additional Notes
- Please double-check that the workflow runs pull the new `9.3.3` image successfully before merging.