### PR TITLE
chore(elasticsearch): bump to 9.4.0 and add bbq_disk bit variants

### DIFF
--- a/.github/workflows/run-elasticsearch-bbq-disk-2bit-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-disk-2bit-linux.yml
@@ -1,4 +1,4 @@
-name: Run Elasticsearch (bbq) benchmark on Linux
+name: Run Elasticsearch (bbq_disk 2-bit) benchmark on Linux
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
       - 'src/search_ann_benchmark/core/**'
       - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/elasticsearch.py'
-      - '.github/workflows/run-elasticsearch-bbq-linux.yml'
+      - '.github/workflows/run-elasticsearch-bbq-disk-2bit-linux.yml'
   pull_request:
     branches:
       - main
@@ -24,7 +24,7 @@ on:
       - 'src/search_ann_benchmark/core/**'
       - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/elasticsearch.py'
-      - '.github/workflows/run-elasticsearch-bbq-linux.yml'
+      - '.github/workflows/run-elasticsearch-bbq-disk-2bit-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:
@@ -76,16 +76,16 @@ jobs:
       - name: Run benchmark
         env:
           TARGET_CONFIG: ${{ github.event.inputs.target_config || '100k-768-m32-efc200-ef100-ip' }}
-          PRODUCT_VARIANT: "bbq"
+          PRODUCT_VARIANT: "bbq_disk_2bit"
         run: |
           uv run search-ann-benchmark run ${ENGINE_NAME} \
             --target ${TARGET_CONFIG} \
             --version ${ENGINE_VERSION} \
-            --quantization bbq \
-            --variant bbq
+            --quantization bbq_disk_2bit \
+            --variant bbq_disk_2bit
 
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:
-          name: elasticsearch-bbq-results
+          name: elasticsearch-bbq-disk-2bit-results
           path: results.json

--- a/.github/workflows/run-elasticsearch-bbq-disk-4bit-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-disk-4bit-linux.yml
@@ -1,4 +1,4 @@
-name: Run Elasticsearch (bbq) benchmark on Linux
+name: Run Elasticsearch (bbq_disk 4-bit) benchmark on Linux
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
       - 'src/search_ann_benchmark/core/**'
       - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/elasticsearch.py'
-      - '.github/workflows/run-elasticsearch-bbq-linux.yml'
+      - '.github/workflows/run-elasticsearch-bbq-disk-4bit-linux.yml'
   pull_request:
     branches:
       - main
@@ -24,7 +24,7 @@ on:
       - 'src/search_ann_benchmark/core/**'
       - 'src/search_ann_benchmark/engines/__init__.py'
       - 'src/search_ann_benchmark/engines/elasticsearch.py'
-      - '.github/workflows/run-elasticsearch-bbq-linux.yml'
+      - '.github/workflows/run-elasticsearch-bbq-disk-4bit-linux.yml'
   workflow_dispatch:
     inputs:
       target_config:
@@ -76,16 +76,16 @@ jobs:
       - name: Run benchmark
         env:
           TARGET_CONFIG: ${{ github.event.inputs.target_config || '100k-768-m32-efc200-ef100-ip' }}
-          PRODUCT_VARIANT: "bbq"
+          PRODUCT_VARIANT: "bbq_disk_4bit"
         run: |
           uv run search-ann-benchmark run ${ENGINE_NAME} \
             --target ${TARGET_CONFIG} \
             --version ${ENGINE_VERSION} \
-            --quantization bbq \
-            --variant bbq
+            --quantization bbq_disk_4bit \
+            --variant bbq_disk_4bit
 
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:
-          name: elasticsearch-bbq-results
+          name: elasticsearch-bbq-disk-4bit-results
           path: results.json

--- a/.github/workflows/run-elasticsearch-bbq-disk-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-disk-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.3.3"
+  ENGINE_VERSION: "9.4.0"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-int4-linux.yml
+++ b/.github/workflows/run-elasticsearch-int4-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.3.3"
+  ENGINE_VERSION: "9.4.0"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-int8-linux.yml
+++ b/.github/workflows/run-elasticsearch-int8-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.3.3"
+  ENGINE_VERSION: "9.4.0"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-linux.yml
+++ b/.github/workflows/run-elasticsearch-linux.yml
@@ -49,7 +49,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.3.3"
+  ENGINE_VERSION: "9.4.0"
 
 jobs:
   benchmark:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This benchmarking suite aims to provide an empirical basis for comparing the per
 | Engine | Version | GitHub Actions |
 |--------|---------|----------------|
 | Qdrant | 1.17.1 | [![Run Qdrant](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml) |
-| Elasticsearch | 9.3.3 | [![Run Elasticsearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml) |
+| Elasticsearch | 9.4.0 | [![Run Elasticsearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml) |
 | OpenSearch | 3.5.0 | [![Run OpenSearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml) |
 | Milvus | 2.6.14 | [![Run Milvus](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml) |
 | Weaviate | 1.36.9 | [![Run Weaviate](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-weaviate-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-weaviate-linux.yml) |
@@ -117,7 +117,7 @@ uv run search-ann-benchmark show-results results.json
 Different engines support different quantization modes:
 
 - **Qdrant**: none, int8
-- **Elasticsearch**: none, int4, int8, bbq
+- **Elasticsearch**: none, int4, int8, bbq, bbq_disk, bbq_disk_2bit, bbq_disk_4bit
 - **OpenSearch**: none (supports faiss engine variant)
 - **Weaviate**: none, pq
 - **pgvector**: vector, halfvec

--- a/src/search_ann_benchmark/cli.py
+++ b/src/search_ann_benchmark/cli.py
@@ -40,7 +40,7 @@ def main() -> None:
 @click.option(
     "--quantization",
     default=None,
-    type=click.Choice(["none", "int4", "int8", "bbq", "bbq_disk", "pq", "byte", "halfvec"]),
+    type=click.Choice(["none", "int4", "int8", "bbq", "bbq_disk", "bbq_disk_2bit", "bbq_disk_4bit", "pq", "byte", "halfvec"]),
     help="Quantization mode",
 )
 @click.option(

--- a/src/search_ann_benchmark/engines/elasticsearch.py
+++ b/src/search_ann_benchmark/engines/elasticsearch.py
@@ -22,7 +22,7 @@ class ElasticsearchConfig(EngineConfig):
     name: str = "elasticsearch"
     host: str = "localhost"
     port: int = 9211
-    version: str = "9.3.3"
+    version: str = "9.4.0"
     container_name: str = "benchmark_es"
     heap: str = "2g"
 
@@ -100,9 +100,18 @@ class ElasticsearchEngine(VectorSearchEngine):
             return "int4_hnsw"
         elif cfg.quantization == "bbq":
             return "bbq_hnsw"
-        elif cfg.quantization == "bbq_disk":
+        elif cfg.quantization in ("bbq_disk", "bbq_disk_2bit", "bbq_disk_4bit"):
             return "bbq_disk"
         return "hnsw"
+
+    def _get_bbq_disk_bits(self) -> int | None:
+        # ES 9.4.0+: bbq_disk supports 1 (default), 2, or 4-bit quantization via index_options.bits
+        cfg = self.dataset_config
+        if cfg.quantization == "bbq_disk_2bit":
+            return 2
+        if cfg.quantization == "bbq_disk_4bit":
+            return 4
+        return None
 
     def create_index(self, number_of_shards: int = 1, number_of_replicas: int = 0) -> None:
         cfg = self.dataset_config
@@ -115,6 +124,10 @@ class ElasticsearchEngine(VectorSearchEngine):
         if knn_type != "bbq_disk":
             index_options["m"] = cfg.hnsw_m
             index_options["ef_construction"] = cfg.hnsw_ef_construction
+        else:
+            bits = self._get_bbq_disk_bits()
+            if bits is not None:
+                index_options["bits"] = bits
 
         response = requests.put(
             f"{self.base_url}/{cfg.index_name}",


### PR DESCRIPTION
## Summary
- Bump Elasticsearch from **9.3.3 → 9.4.0** across all 5 workflows, the engine config, and the README. No breaking changes affect the benchmark code.
- Add two new benchmark variants leveraging 9.4.0's configurable DiskBBQ quantization level (PR [elastic/elasticsearch#139944](https://github.com/elastic/elasticsearch/pull/139944)): `bbq_disk_2bit` and `bbq_disk_4bit`. The existing `bbq_disk` variant continues to use the ES default (1-bit).

## Variant matrix
| `--quantization` | `index_options.type` | `index_options.bits` |
|---|---|---|
| `bbq_disk` | `bbq_disk` | (omitted → ES default = 1-bit) |
| `bbq_disk_2bit` | `bbq_disk` | `2` |
| `bbq_disk_4bit` | `bbq_disk` | `4` |

## Notable 9.4.0 changes (vector search)
- DiskBBQ algorithm upgrade: ~3x perf on filtered search; configurable quantization bits (1/2/4)
- AVX-512 / ARM SIMD optimizations for int4, int7u, int8, bfloat16 scoring
- New `flat_index_threshold` HNSW parameter (not exercised by this benchmark)
- New default index type for new indices is `bbq_disk` — no impact here because `engines/elasticsearch.py` sets `index_options.type` explicitly

## Test plan
- [x] `uv run pytest tests/` — 19 passed
- [x] CLI `--help` shows new quantization choices: `bbq_disk_2bit`, `bbq_disk_4bit`
- [x] Mapping verified: `bbq_disk_2bit` → `bits=2`, `bbq_disk_4bit` → `bits=4`, `bbq_disk` → no `bits` field (ES default)
- [x] No new ruff/mypy errors introduced (pre-existing baseline issues only)
- [ ] CI: `run-elasticsearch-linux` (and quantization variants) green on the gha dataset
- [ ] CI: new `run-elasticsearch-bbq-disk-2bit-linux` and `run-elasticsearch-bbq-disk-4bit-linux` green