### PR TITLE
chore(elasticsearch): bump Elasticsearch version from 9.4.0 to 9.4.1

### DIFF
--- a/.github/workflows/run-elasticsearch-bbq-disk-2bit-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-disk-2bit-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.4.0"
+  ENGINE_VERSION: "9.4.1"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-bbq-disk-4bit-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-disk-4bit-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.4.0"
+  ENGINE_VERSION: "9.4.1"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-bbq-disk-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-disk-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.4.0"
+  ENGINE_VERSION: "9.4.1"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-bbq-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.4.0"
+  ENGINE_VERSION: "9.4.1"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-int4-linux.yml
+++ b/.github/workflows/run-elasticsearch-int4-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.4.0"
+  ENGINE_VERSION: "9.4.1"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-int8-linux.yml
+++ b/.github/workflows/run-elasticsearch-int8-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.4.0"
+  ENGINE_VERSION: "9.4.1"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-linux.yml
+++ b/.github/workflows/run-elasticsearch-linux.yml
@@ -49,7 +49,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.4.0"
+  ENGINE_VERSION: "9.4.1"
 
 jobs:
   benchmark:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This benchmarking suite aims to provide an empirical basis for comparing the per
 | Engine | Version | GitHub Actions |
 |--------|---------|----------------|
 | Qdrant | 1.17.1 | [![Run Qdrant](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml) |
-| Elasticsearch | 9.4.0 | [![Run Elasticsearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml) |
+| Elasticsearch | 9.4.1 | [![Run Elasticsearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml) |
 | OpenSearch | 3.5.0 | [![Run OpenSearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml) |
 | Milvus | 2.6.14 | [![Run Milvus](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml) |
 | Weaviate | 1.36.9 | [![Run Weaviate](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-weaviate-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-weaviate-linux.yml) |

--- a/src/search_ann_benchmark/engines/elasticsearch.py
+++ b/src/search_ann_benchmark/engines/elasticsearch.py
@@ -22,7 +22,7 @@ class ElasticsearchConfig(EngineConfig):
     name: str = "elasticsearch"
     host: str = "localhost"
     port: int = 9211
-    version: str = "9.4.0"
+    version: str = "9.4.1"
     container_name: str = "benchmark_es"
     heap: str = "2g"
 


### PR DESCRIPTION
## Summary
- Bump Elasticsearch from **9.4.0** to **9.4.1** (latest stable as of 2026-05-12).
- Updates the version in all 3 sync points: Python config (`engines/elasticsearch.py`), the 7 GitHub Actions workflows (standard, int8, int4, bbq, bbq_disk, bbq_disk_2bit, bbq_disk_4bit), and the Supported Engines table in `README.md`.

## Release Notes
9.4.1 is a pure bug-fix patch. The only vector-search change is a DiskBBQ correctness fix — [`[DiskBBQ] Check that precondition should not be overwritten on update` (#148111)](https://github.com/elastic/elasticsearch/pull/148111) — which directly benefits the `bbq_disk` variants this project benchmarks. No breaking API changes, no deprecations, no Docker image changes, and HNSW / int8 / int4 / `dense_vector` mapping are untouched.

## Test plan
- [ ] CI workflow `run-elasticsearch-linux.yml` passes against the `gha` dataset
- [ ] CI workflow `run-elasticsearch-int8-linux.yml` passes
- [ ] CI workflow `run-elasticsearch-int4-linux.yml` passes
- [ ] CI workflow `run-elasticsearch-bbq-linux.yml` passes
- [ ] CI workflow `run-elasticsearch-bbq-disk-linux.yml` passes
- [ ] CI workflow `run-elasticsearch-bbq-disk-2bit-linux.yml` passes
- [ ] CI workflow `run-elasticsearch-bbq-disk-4bit-linux.yml` passes