### PR TITLE
chore(opensearch): bump OpenSearch version from 3.5.0 to 3.6.0

### DIFF
--- a/.github/workflows/run-opensearch-faiss-linux.yml
+++ b/.github/workflows/run-opensearch-faiss-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: opensearch
-  ENGINE_VERSION: "3.5.0"
+  ENGINE_VERSION: "3.6.0"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-opensearch-linux.yml
+++ b/.github/workflows/run-opensearch-linux.yml
@@ -47,7 +47,7 @@ on:
 
 env:
   ENGINE_NAME: opensearch
-  ENGINE_VERSION: "3.5.0"
+  ENGINE_VERSION: "3.6.0"
 
 jobs:
   benchmark:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This benchmarking suite aims to provide an empirical basis for comparing the per
 |--------|---------|----------------|
 | Qdrant | 1.17.1 | [![Run Qdrant](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml) |
 | Elasticsearch | 9.4.1 | [![Run Elasticsearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml) |
-| OpenSearch | 3.5.0 | [![Run OpenSearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml) |
+| OpenSearch | 3.6.0 | [![Run OpenSearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml) |
 | Milvus | 2.6.14 | [![Run Milvus](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml) |
 | Weaviate | 1.36.9 | [![Run Weaviate](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-weaviate-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-weaviate-linux.yml) |
 | Vespa | 8.667.16 | [![Run Vespa](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-vespa-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-vespa-linux.yml) |

--- a/src/search_ann_benchmark/engines/opensearch.py
+++ b/src/search_ann_benchmark/engines/opensearch.py
@@ -23,7 +23,7 @@ class OpenSearchConfig(EngineConfig):
     name: str = "opensearch"
     host: str = "localhost"
     port: int = 9212
-    version: str = "3.5.0"
+    version: str = "3.6.0"
     container_name: str = "benchmark_opensearch"
     heap: str = "2g"
     engine: str = "lucene"  # or "faiss"


### PR DESCRIPTION
## Summary
- Bump OpenSearch from **3.5.0** to **3.6.0** across the engine config, both workflows (`run-opensearch-linux.yml`, `run-opensearch-faiss-linux.yml`), and the README supported-engines table.
- No code changes required: 3.6.0 is additive (Lucene 10.4.0, Faiss Scalar Quantization 1-bit, Lucene BBQ Flat 1-bit, pre-quantized exact search, Hamming scorer for byte vectors, FP16 bulk perf, abortable native engine merges) with no breaking changes to the `knn_vector` + HNSW (`lucene`/`faiss`) + `_bulk` paths used by this benchmark.
- Docker image `opensearchproject/opensearch:3.6.0` is published on Docker Hub.

## Test plan
- [ ] `Run OpenSearch` workflow (lucene) passes on the `gha` dataset
- [ ] `Run OpenSearch (faiss)` workflow passes on the `gha` dataset
- [ ] `uv run search-ann-benchmark run opensearch --target 100k-768-m32-efc200-ef100-ip` succeeds locally