### PR TITLE
fix(elasticsearch): restore bbq_disk Precision@k on 9.4+

### DIFF
--- a/src/search_ann_benchmark/engines/elasticsearch.py
+++ b/src/search_ann_benchmark/engines/elasticsearch.py
@@ -104,14 +104,22 @@ class ElasticsearchEngine(VectorSearchEngine):
             return "bbq_disk"
         return "hnsw"
 
-    def _get_bbq_disk_bits(self) -> int | None:
+    def _get_bbq_disk_bits(self) -> int:
         # ES 9.4.0+: bbq_disk supports 1 (default), 2, or 4-bit quantization via index_options.bits
         cfg = self.dataset_config
         if cfg.quantization == "bbq_disk_2bit":
             return 2
         if cfg.quantization == "bbq_disk_4bit":
             return 4
-        return None
+        return 1
+
+    def _get_bbq_disk_oversample(self) -> float:
+        # ES 9.4.0+: auto oversampling_factor by bits. Set explicitly because the
+        # auto value only applies reliably when bits is set in index_options and
+        # rescore_vector is provided on the query. Without an explicit oversample,
+        # 9.4's new DiskBBQ defaults can yield 0 precision on small datasets.
+        bits = self._get_bbq_disk_bits()
+        return {1: 3.0, 2: 1.5, 4: 1.0, 7: 1.0}.get(bits, 3.0)
 
     def create_index(self, number_of_shards: int = 1, number_of_replicas: int = 0) -> None:
         cfg = self.dataset_config
@@ -125,9 +133,8 @@ class ElasticsearchEngine(VectorSearchEngine):
             index_options["m"] = cfg.hnsw_m
             index_options["ef_construction"] = cfg.hnsw_ef_construction
         else:
-            bits = self._get_bbq_disk_bits()
-            if bits is not None:
-                index_options["bits"] = bits
+            # Always set bits explicitly so 9.4's auto oversampling_factor kicks in
+            index_options["bits"] = self._get_bbq_disk_bits()
 
         response = requests.put(
             f"{self.base_url}/{cfg.index_name}",
@@ -304,13 +311,18 @@ class ElasticsearchEngine(VectorSearchEngine):
         cfg = self.dataset_config
         num_candidates = max(cfg.hnsw_ef, top_k)
 
-        query: dict[str, Any] = {
-            "knn": {
-                "field": "embedding",
-                "query_vector": query_vector,
-                "num_candidates": num_candidates,
-            }
+        knn: dict[str, Any] = {
+            "field": "embedding",
+            "query_vector": query_vector,
+            "num_candidates": num_candidates,
         }
+        # ES 9.4.0 rewrote DiskBBQ (PR #143760) and changed the default
+        # visit_percentage formula (PR #142784). Without an explicit
+        # rescore_vector, small datasets yield ~0 Precision@k.
+        if self._get_knn_type() == "bbq_disk":
+            knn["rescore_vector"] = {"oversample": self._get_bbq_disk_oversample()}
+
+        query: dict[str, Any] = {"knn": knn}
 
         if filter_query:
             query["knn"]["filter"] = filter_query

--- a/src/search_ann_benchmark/engines/elasticsearch.py
+++ b/src/search_ann_benchmark/engines/elasticsearch.py
@@ -64,6 +64,11 @@ class ElasticsearchEngine(VectorSearchEngine):
             "-e", "discovery.type=single-node",
             "-e", "bootstrap.memory_lock=true",
             "-e", "xpack.security.enabled=false",
+            # Trial license enables commercial features required by some
+            # quantization types (notably `bbq_disk`, which is non-compliant
+            # under the default basic license since 9.4 and rejects writes
+            # with HTTP 403 / security_exception).
+            "-e", "xpack.license.self_generated.type=trial",
             "-e", f"ES_JAVA_OPTS=-Xms{self.es_config.heap}",
             f"docker.elastic.co/elasticsearch/elasticsearch:{self.engine_config.version}",
         ]


### PR DESCRIPTION
## Summary

On Elasticsearch 9.4.x the `bbq_disk` variant of this benchmark reports `hits=0, Precision@10=0.0` while `took` stays near zero (≈ 5 ms). Initial run on this branch ([artifact from #42 run 25840431008](https://github.com/codelibs/search-ann-benchmark/actions/runs/25840431008)) revealed the actual root cause:

```
status: 403
type: "security_exception"
reason: "current license is non-compliant for [bbq_disk]"
license.expired.feature: "bbq_disk"
```

Every bulk insert was rejected → the index was empty → every query returned 0 hits → precision was 0.

Since [elastic/elasticsearch#144885](https://github.com/elastic/elasticsearch/pull/144885) (9.4.0) **`bbq_disk` is a commercial feature** and is not enabled under the default `basic` self-generated license that this benchmark's container starts with.

### Changes

`src/search_ann_benchmark/engines/elasticsearch.py`:

1. **Trial license on container start** *(primary fix)*  
   Pass `xpack.license.self_generated.type=trial` to the Docker `run` command. Trial unlocks all commercial features for 30 days; benchmark containers are recreated on every run, so the 30-day window never expires.

2. **Explicit `index_options.bits` for `bbq_disk`** *(9.4 correctness)*  
   `_get_bbq_disk_bits()` now returns the explicit default `1` (was `None`) and `create_index()` always writes `index_options.bits`. Per the official 9.4 BBQ docs, the documented auto `oversampling_factor` (1 → 3.0, 2 → 1.5, 4/7 → 0) only takes effect reliably when `bits` is set explicitly.

3. **Explicit `rescore_vector` on `bbq_disk` queries** *(9.4 precision)*  
   `search()` now adds `rescore_vector: { "oversample": <factor> }` to the `knn` query when `knn_type == "bbq_disk"`. ES 9.4 rewrote DiskBBQ ([#143760](https://github.com/elastic/elasticsearch/pull/143760)) and changed the default `visit_percentage` formula ([#142784](https://github.com/elastic/elasticsearch/pull/142784)); without an explicit rescore the final ranking comes purely from the quantized comparison and recall against a brute-force ground truth is poor.

Other variants (`hnsw`, `int8_hnsw`, `int4_hnsw`, `bbq_hnsw`) are unchanged — the `bbq_disk` branches in `create_index()` and `search()` are guarded.

## Test plan

- [x] `uv run pytest` — 19 tests pass.
- [x] PR CI run that surfaced the licensing 403 errors: `25840431008`.
- [ ] Re-run `run-elasticsearch-bbq-disk-linux.yml` against `100k-768-m32-efc200-ef100-ip` (triggered by this push) and confirm:
  - `Partial bulk failure` warnings are gone.
  - `top_10.hits.mean ≈ 10` and `top_10.precision.mean ≫ 0`.
- [ ] Re-run `run-elasticsearch-bbq-disk-2bit-linux.yml` and `…-4bit-linux.yml`; tune `_get_bbq_disk_oversample` if 4-bit recall is too low.
- [ ] Sanity-check that the unaffected ES variants (default HNSW, `int8`, `int4`, `bbq_hnsw`) still report comparable numbers under the trial license — the trial only unlocks features, it does not change basic-tier behavior.

## Follow-ups (not in this PR)

- Consider switching `_source: { "excludes": ["embedding"] }` to `index.mapping.exclude_source_vectors: true` (the 9.4-recommended pattern).
- Document in `README.md` that the Elasticsearch benchmark now runs under a self-generated trial license so that commercial features such as `bbq_disk` are exercised.