### PR TITLE
chore(qdrant): bump Qdrant version from 1.17.1 to 1.18.0

### DIFF
--- a/.github/workflows/run-qdrant-int8-linux.yml
+++ b/.github/workflows/run-qdrant-int8-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: qdrant
-  ENGINE_VERSION: "1.17.1"
+  ENGINE_VERSION: "1.18.0"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-qdrant-linux.yml
+++ b/.github/workflows/run-qdrant-linux.yml
@@ -47,7 +47,7 @@ on:
 
 env:
   ENGINE_NAME: qdrant
-  ENGINE_VERSION: "1.17.1"
+  ENGINE_VERSION: "1.18.0"
 
 jobs:
   benchmark:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This benchmarking suite aims to provide an empirical basis for comparing the per
 
 | Engine | Version | GitHub Actions |
 |--------|---------|----------------|
-| Qdrant | 1.17.1 | [![Run Qdrant](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml) |
+| Qdrant | 1.18.0 | [![Run Qdrant](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml) |
 | Elasticsearch | 9.4.1 | [![Run Elasticsearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml) |
 | OpenSearch | 3.6.0 | [![Run OpenSearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml) |
 | Milvus | 2.6.14 | [![Run Milvus](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml) |

--- a/src/search_ann_benchmark/engines/qdrant.py
+++ b/src/search_ann_benchmark/engines/qdrant.py
@@ -22,7 +22,7 @@ class QdrantConfig(EngineConfig):
     name: str = "qdrant"
     host: str = "localhost"
     port: int = 6344
-    version: str = "1.17.1"
+    version: str = "1.18.0"
     container_name: str = "benchmark_qdrant"
 
 


### PR DESCRIPTION
## Summary
- Bump Qdrant from `1.17.1` to `1.18.0` ([release notes](https://github.com/qdrant/qdrant/releases/tag/v1.18.0)).
- Updates the version in all three sync points: Python engine config, both Qdrant workflows (standard + int8), and the Supported Engines table in `README.md`.
- Minor bump with no breaking changes to the REST endpoints used by `engines/qdrant.py` (`/collections`, `/points`, `/points/search`, `/cluster`). New features (TurboQuant quantization, named-vector API, low-memory mode) are opt-in and do not affect existing benchmark usage. The internal RocksDB removal is transparent for fresh-container benchmark runs.

## Test plan
- [ ] CI: `Run Qdrant` workflow passes on the `gha` dataset
- [ ] CI: `Run Qdrant (int8)` workflow passes on the `gha` dataset
- [ ] Local smoke test: `uv run search-ann-benchmark run qdrant` completes successfully