### PR TITLE
perf(core): improve sub-millisecond latency measurement precision

### DIFF
--- a/src/search_ann_benchmark/core/base.py
+++ b/src/search_ann_benchmark/core/base.py
@@ -200,7 +200,7 @@ class VectorSearchEngine(ABC):
             stable_count: Number of consecutive stable checks required
         """
         logger.debug(f"Waiting for indexing to complete (stable_count={stable_count}, interval={check_interval}s)")
-        start = time.time()
+        start = time.perf_counter()
         count = 0
         total_checks = 0
         while count < stable_count:
@@ -210,13 +210,13 @@ class VectorSearchEngine(ABC):
                 count += 1
             else:
                 count = 0
-            elapsed = time.time() - start
+            elapsed = time.perf_counter() - start
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(f"Indexing check {total_checks}: complete={is_complete}, stable_count={count}/{stable_count}, elapsed={elapsed:.1f}s")
             else:
                 print(".", end="", flush=True)
             time.sleep(check_interval)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         if not logger.isEnabledFor(logging.DEBUG):
             print(".")
         logger.debug(f"Indexing complete after {total_checks} checks in {elapsed:.1f}s")

--- a/src/search_ann_benchmark/core/docker.py
+++ b/src/search_ann_benchmark/core/docker.py
@@ -31,9 +31,9 @@ class DockerManager:
         """
         logger.info(f"Starting {self.container_name}...")
         logger.debug(f"Command: {' '.join(docker_cmd)}")
-        start = time.time()
+        start = time.perf_counter()
         result = subprocess.run(docker_cmd, capture_output=True, text=True)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         if result.returncode == 0:
             logger.info(f"Started {self.container_name} in {elapsed:.1f}s [OK]")
             logger.debug(f"stdout: {result.stdout[:500] if result.stdout else '(empty)'}")
@@ -51,13 +51,13 @@ class DockerManager:
             True if successful
         """
         logger.info(f"Stopping {self.container_name}...")
-        start = time.time()
+        start = time.perf_counter()
         result = subprocess.run(
             ["docker", "stop", self.container_name],
             capture_output=True,
             text=True,
         )
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         if result.returncode == 0:
             logger.info(f"Stopped {self.container_name} in {elapsed:.1f}s [OK]")
             return True
@@ -75,13 +75,13 @@ class DockerManager:
             True if successful
         """
         logger.debug("Running docker system prune...")
-        start = time.time()
+        start = time.perf_counter()
         result = subprocess.run(
             ["docker", "system", "prune", "-f"],
             capture_output=True,
             text=True,
         )
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         if result.returncode == 0:
             logger.debug(f"Docker prune completed in {elapsed:.1f}s [OK]")
             return True
@@ -158,9 +158,9 @@ class DockerManager:
 
         logger.info(f"Starting services from {compose_file}...")
         logger.debug(f"Command: {' '.join(cmd)}")
-        start = time.time()
+        start = time.perf_counter()
         result = subprocess.run(cmd, capture_output=True, text=True)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         if result.returncode == 0:
             logger.info(f"Services started in {elapsed:.1f}s [OK]")
             return True
@@ -186,9 +186,9 @@ class DockerManager:
 
         logger.info(f"Stopping services from {compose_file}...")
         logger.debug(f"Command: {' '.join(cmd)}")
-        start = time.time()
+        start = time.perf_counter()
         result = subprocess.run(cmd, capture_output=True, text=True)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         if result.returncode == 0:
             logger.info(f"Services stopped in {elapsed:.1f}s [OK]")
             return True

--- a/src/search_ann_benchmark/core/measurement.py
+++ b/src/search_ann_benchmark/core/measurement.py
@@ -1,0 +1,143 @@
+"""Utilities for reducing measurement noise during latency benchmarks.
+
+The functions and context manager defined here aim to minimize sources of
+jitter that can dominate sub-millisecond search latencies:
+
+- Pause Python's cyclic garbage collector during the measurement window so
+  GC pauses do not appear inside individual query timings.
+- Raise process priority (``os.nice``) so the benchmark loop is less likely
+  to be descheduled by background tasks.
+- Pin the process to a single CPU core (Linux only) so per-query timings
+  do not include cross-core migration costs.
+
+All operations degrade gracefully: failure to elevate priority or set CPU
+affinity is logged at WARNING level but does not abort the benchmark.
+"""
+
+from __future__ import annotations
+
+import gc
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from search_ann_benchmark.core.logging import get_logger
+
+logger = get_logger("measurement")
+
+
+def _try_raise_priority(nice_delta: int = -10) -> int | None:
+    """Attempt to raise the current process priority.
+
+    Args:
+        nice_delta: Value passed to ``os.nice``. Negative values increase
+            priority and typically require elevated permissions on Linux.
+
+    Returns:
+        The new nice value on success, or ``None`` if priority could not be
+        adjusted (e.g. ``PermissionError`` on a non-privileged user).
+    """
+    try:
+        new_nice = os.nice(nice_delta)
+        logger.debug(f"Raised process priority: nice={new_nice}")
+        return new_nice
+    except (PermissionError, OSError) as exc:
+        logger.warning(
+            f"Could not raise process priority via os.nice({nice_delta}): "
+            f"{type(exc).__name__}: {exc}. "
+            "Run with elevated privileges or set CAP_SYS_NICE for tighter timings."
+        )
+        return None
+
+
+def _try_pin_cpu() -> frozenset[int] | None:
+    """Pin the current process to a single CPU core.
+
+    Returns:
+        The previous CPU affinity mask on success (so it can be restored),
+        or ``None`` if affinity could not be applied (non-Linux platform,
+        ``PermissionError``, etc.).
+    """
+    if not hasattr(os, "sched_setaffinity") or not hasattr(os, "sched_getaffinity"):
+        logger.debug("CPU affinity not supported on this platform; skipping pin.")
+        return None
+    try:
+        previous = frozenset(os.sched_getaffinity(0))  # type: ignore[attr-defined]
+        if not previous:
+            logger.warning("Empty CPU affinity mask; skipping pin.")
+            return None
+        target = min(previous)
+        os.sched_setaffinity(0, {target})  # type: ignore[attr-defined]
+        logger.debug(f"Pinned process to CPU {target} (previous affinity: {sorted(previous)})")
+        return previous
+    except (PermissionError, OSError) as exc:
+        logger.warning(
+            f"Could not set CPU affinity: {type(exc).__name__}: {exc}. "
+            "Latency measurements may include cross-core migration jitter."
+        )
+        return None
+
+
+def _restore_cpu_affinity(previous: frozenset[int] | None) -> None:
+    """Restore CPU affinity to the previously captured mask."""
+    if previous is None:
+        return
+    if not hasattr(os, "sched_setaffinity"):
+        return
+    try:
+        os.sched_setaffinity(0, set(previous))  # type: ignore[attr-defined]
+        logger.debug(f"Restored CPU affinity: {sorted(previous)}")
+    except OSError as exc:
+        logger.warning(f"Could not restore CPU affinity: {type(exc).__name__}: {exc}")
+
+
+@contextmanager
+def low_noise_measurement(
+    *,
+    pin_cpu: bool = True,
+    raise_priority: bool = True,
+    disable_gc: bool = True,
+) -> Iterator[None]:
+    """Context manager that reduces measurement noise during a benchmark.
+
+    On entry the manager:
+        1. Runs a full ``gc.collect()`` to drain pending cycles, then
+           disables the cyclic GC (if ``disable_gc`` is True).
+        2. Raises process priority via ``os.nice`` (if ``raise_priority``
+           is True). Failures are logged but otherwise ignored.
+        3. Pins the process to a single CPU core (if ``pin_cpu`` is True
+           and the platform supports ``os.sched_setaffinity``).
+
+    On exit the GC is re-enabled and CPU affinity is restored to its
+    previous mask. ``os.nice`` cannot be lowered back (it is monotonic for
+    unprivileged processes) so priority is left as-is.
+
+    Args:
+        pin_cpu: Whether to pin to a single CPU core on Linux.
+        raise_priority: Whether to attempt to raise process priority.
+        disable_gc: Whether to disable the cyclic garbage collector.
+
+    Yields:
+        None.
+    """
+    gc_was_enabled = gc.isenabled()
+    previous_affinity: frozenset[int] | None = None
+    try:
+        if disable_gc:
+            gc.collect()
+            gc.disable()
+            logger.debug("Disabled cyclic GC for measurement window.")
+        if raise_priority:
+            _try_raise_priority()
+        if pin_cpu:
+            previous_affinity = _try_pin_cpu()
+        yield
+    finally:
+        if disable_gc and gc_was_enabled:
+            gc.enable()
+            logger.debug("Re-enabled cyclic GC after measurement window.")
+        if pin_cpu:
+            _restore_cpu_affinity(previous_affinity)
+
+
+__all__ = ["low_noise_measurement"]

--- a/src/search_ann_benchmark/engines/chroma.py
+++ b/src/search_ann_benchmark/engines/chroma.py
@@ -49,9 +49,9 @@ class ChromaEngine(VectorSearchEngine):
 
     def wait_until_ready(self, timeout: int = 60) -> bool:
         logger.info(f"Waiting for {self.engine_config.container_name}...")
-        start = time.time()
+        start = time.perf_counter()
         for attempt in range(timeout):
-            elapsed = time.time() - start
+            elapsed = time.perf_counter() - start
             try:
                 logger.debug(f"Health check attempt {attempt+1}/{timeout}, elapsed={elapsed:.1f}s")
                 response = requests.get(f"{self.base_url}/api/v2/heartbeat", timeout=5)
@@ -131,14 +131,14 @@ class ChromaEngine(VectorSearchEngine):
         # Convert integer IDs to strings (Chroma requires string IDs)
         str_ids = list(map(str, ids))
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         try:
             self._get_collection().add(
                 embeddings=embeddings,
                 metadatas=documents,
                 ids=str_ids,
             )
-            elapsed = time.time() - start_time
+            elapsed = time.perf_counter() - start_time
             logger.debug(f"Insert completed: {len(ids)} docs in {elapsed:.3f}s [OK]")
             return elapsed
         except Exception as e:
@@ -160,10 +160,10 @@ class ChromaEngine(VectorSearchEngine):
         if filter_query:
             query["where"] = filter_query
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         try:
             result = self._get_collection().query(**query)
-            took_ms = (time.time() - start_time) * 1000
+            took_ms = (time.perf_counter() - start_time) * 1000
 
             ids_list = result.get("ids", [[]])[0]
             distances = result.get("distances", [[]])[0]

--- a/src/search_ann_benchmark/engines/clickhouse.py
+++ b/src/search_ann_benchmark/engines/clickhouse.py
@@ -110,9 +110,9 @@ class ClickHouseEngine(VectorSearchEngine):
 
     def wait_until_ready(self, timeout: int = 60) -> bool:
         logger.info(f"Waiting for {self.engine_config.container_name}...")
-        start = time.time()
+        start = time.perf_counter()
         for attempt in range(timeout):
-            elapsed = time.time() - start
+            elapsed = time.perf_counter() - start
             try:
                 logger.debug(f"Health check attempt {attempt+1}/{timeout}, elapsed={elapsed:.1f}s")
                 response = requests.get(f"{self.base_url}/ping", timeout=5)
@@ -222,7 +222,7 @@ class ClickHouseEngine(VectorSearchEngine):
         insert_data = "\n".join(rows)
         insert_sql = f"INSERT INTO {cfg.index_name} FORMAT JSONEachRow"
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         try:
             response = self._get_session().post(
                 f"{self.base_url}/",
@@ -234,7 +234,7 @@ class ClickHouseEngine(VectorSearchEngine):
             if response.status_code != 200:
                 raise Exception(f"Insert failed: {response.status_code} - {response.text}")
 
-            elapsed = time.time() - start_time
+            elapsed = time.perf_counter() - start_time
             print(f"[OK] {elapsed:.3f}s")
             return elapsed
         except Exception as e:
@@ -320,10 +320,10 @@ class ClickHouseEngine(VectorSearchEngine):
                 {settings_clause}
         """
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         try:
             result = self._execute_query(query, timeout=30)
-            took_ms = (time.time() - start_time) * 1000
+            took_ms = (time.perf_counter() - start_time) * 1000
 
             data = result.get("data", [])
             ids = [int(row.get("doc_id", 0)) for row in data]

--- a/src/search_ann_benchmark/engines/elasticsearch.py
+++ b/src/search_ann_benchmark/engines/elasticsearch.py
@@ -75,9 +75,9 @@ class ElasticsearchEngine(VectorSearchEngine):
 
     def wait_until_ready(self, timeout: int = 60) -> bool:
         logger.info(f"Waiting for {self.engine_config.container_name}...")
-        start = time.time()
+        start = time.perf_counter()
         for attempt in range(timeout):
-            elapsed = time.time() - start
+            elapsed = time.perf_counter() - start
             try:
                 logger.debug(f"Health check attempt {attempt+1}/{timeout}, elapsed={elapsed:.1f}s")
                 response = requests.get(f"{self.base_url}/", timeout=5)
@@ -232,14 +232,14 @@ class ElasticsearchEngine(VectorSearchEngine):
 
         bulk_body = self._generate_bulk_ndjson(documents, embeddings, ids)
 
-        start = time.time()
+        start = time.perf_counter()
         logger.debug(f"POST {self.base_url}/_bulk starting")
         response = requests.post(
             f"{self.base_url}/_bulk",
             headers={"Content-Type": "application/x-ndjson"},
             data=bulk_body,
         )
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
 
         if response.status_code == 200:
             result = response.json()
@@ -266,9 +266,9 @@ class ElasticsearchEngine(VectorSearchEngine):
     def flush_index(self) -> None:
         cfg = self.dataset_config
         logger.info(f"Flushing {cfg.index_name}...")
-        start = time.time()
+        start = time.perf_counter()
         response = requests.post(f"{self.base_url}/{cfg.index_name}/_flush", timeout=600)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         if response.status_code == 200:
             logger.info(f"Flush completed in {elapsed:.1f}s [OK]")
         else:
@@ -277,9 +277,9 @@ class ElasticsearchEngine(VectorSearchEngine):
     def refresh_index(self) -> None:
         cfg = self.dataset_config
         logger.info(f"Refreshing {cfg.index_name}...")
-        start = time.time()
+        start = time.perf_counter()
         response = requests.post(f"{self.base_url}/{cfg.index_name}/_refresh", timeout=600)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         if response.status_code == 200:
             logger.info(f"Refresh completed in {elapsed:.1f}s [OK]")
         else:
@@ -288,9 +288,9 @@ class ElasticsearchEngine(VectorSearchEngine):
     def close_index(self) -> None:
         cfg = self.dataset_config
         logger.info(f"Closing {cfg.index_name}...")
-        start = time.time()
+        start = time.perf_counter()
         response = requests.post(f"{self.base_url}/{cfg.index_name}/_close", timeout=600)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         if response.status_code == 200:
             logger.info(f"Close completed in {elapsed:.1f}s [OK]")
         else:
@@ -299,9 +299,9 @@ class ElasticsearchEngine(VectorSearchEngine):
     def open_index(self) -> None:
         cfg = self.dataset_config
         logger.info(f"Opening {cfg.index_name}...")
-        start = time.time()
+        start = time.perf_counter()
         response = requests.post(f"{self.base_url}/{cfg.index_name}/_open", timeout=600)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         if response.status_code == 200:
             logger.info(f"Open completed in {elapsed:.1f}s [OK]")
         else:
@@ -310,9 +310,9 @@ class ElasticsearchEngine(VectorSearchEngine):
     def forcemerge_index(self) -> None:
         cfg = self.dataset_config
         logger.info(f"Merging {cfg.index_name}...")
-        start = time.time()
+        start = time.perf_counter()
         response = requests.post(f"{self.base_url}/{cfg.index_name}/_forcemerge?max_num_segments=1", timeout=3600)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         if response.status_code == 200:
             logger.info(f"Merge completed in {elapsed:.1f}s [OK]")
         else:

--- a/src/search_ann_benchmark/engines/lancedb.py
+++ b/src/search_ann_benchmark/engines/lancedb.py
@@ -188,10 +188,10 @@ class LanceDBEngine(VectorSearchEngine):
                 "section": doc.get("section", ""),
             })
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         try:
             self._get_table().add(data)
-            elapsed = time.time() - start_time
+            elapsed = time.perf_counter() - start_time
             logger.debug(f"Insert completed: {len(ids)} docs in {elapsed:.3f}s [OK]")
             print(f"[OK] {elapsed:.3f}s")
             return elapsed
@@ -206,9 +206,9 @@ class LanceDBEngine(VectorSearchEngine):
         LanceDB builds indexes after data insertion for optimal performance.
         """
         logger.info("Building vector index...")
-        start = time.time()
+        start = time.perf_counter()
         self._create_vector_index()
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         logger.info(f"Vector index built in {elapsed:.1f}s")
 
         # Create scalar index for filtering
@@ -228,7 +228,7 @@ class LanceDBEngine(VectorSearchEngine):
         """Execute a vector search query."""
         cfg = self.dataset_config
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         try:
             # Build query
             query = self._get_table().search(query_vector)
@@ -250,7 +250,7 @@ class LanceDBEngine(VectorSearchEngine):
             query = query.refine_factor(2)
 
             results = query.limit(top_k).to_list()
-            took_ms = (time.time() - start_time) * 1000
+            took_ms = (time.perf_counter() - start_time) * 1000
 
             # Extract results
             ids_list = [int(r.get("id", 0)) for r in results]

--- a/src/search_ann_benchmark/engines/milvus.py
+++ b/src/search_ann_benchmark/engines/milvus.py
@@ -140,9 +140,9 @@ networks:
 
     def wait_until_ready(self, timeout: int = 120) -> bool:
         logger.info(f"Waiting for {self.engine_config.container_name}...")
-        start = time.time()
+        start = time.perf_counter()
         for attempt in range(timeout):
-            elapsed = time.time() - start
+            elapsed = time.perf_counter() - start
             try:
                 logger.debug(f"Health check attempt {attempt+1}/{timeout}, elapsed={elapsed:.1f}s")
                 response = requests.post(
@@ -255,13 +255,13 @@ networks:
             for doc, embedding, doc_id in zip(documents, embeddings, ids)
         ]
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         response = requests.post(
             f"{self.base_url}/v1/vector/insert",
             headers={"Accept": "application/json", "Content-Type": "application/json"},
             json={"collectionName": cfg.index_name, "data": docs},
         )
-        elapsed = time.time() - start_time
+        elapsed = time.perf_counter() - start_time
 
         result = response.json()
         if result.get("code") == 200:
@@ -293,14 +293,14 @@ networks:
         if filter_query:
             query["filter"] = filter_query
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         response = self._get_session().post(
             f"{self.base_url}/v2/vectordb/entities/search",
             headers={"Accept": "application/json", "Content-Type": "application/json"},
             json=query,
             timeout=10,
         )
-        took_ms = (time.time() - start_time) * 1000
+        took_ms = (time.perf_counter() - start_time) * 1000
 
         obj = response.json()
         if obj.get("code") == 0:

--- a/src/search_ann_benchmark/engines/opensearch.py
+++ b/src/search_ann_benchmark/engines/opensearch.py
@@ -77,9 +77,9 @@ class OpenSearchEngine(VectorSearchEngine):
 
     def wait_until_ready(self, timeout: int = 60) -> bool:
         logger.info(f"Waiting for {self.engine_config.container_name}...")
-        start = time.time()
+        start = time.perf_counter()
         for attempt in range(timeout):
-            elapsed = time.time() - start
+            elapsed = time.perf_counter() - start
             try:
                 logger.debug(f"Health check attempt {attempt+1}/{timeout}, elapsed={elapsed:.1f}s")
                 response = requests.get(f"{self.base_url}/", timeout=5)
@@ -184,13 +184,13 @@ class OpenSearchEngine(VectorSearchEngine):
 
         bulk_body = self._generate_bulk_ndjson(documents, embeddings, ids)
 
-        start = time.time()
+        start = time.perf_counter()
         response = requests.post(
             f"{self.base_url}/_bulk",
             headers={"Content-Type": "application/x-ndjson"},
             data=bulk_body,
         )
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
 
         if response.status_code == 200:
             result = response.json()
@@ -217,9 +217,9 @@ class OpenSearchEngine(VectorSearchEngine):
     def flush_index(self) -> None:
         cfg = self.dataset_config
         logger.info(f"Flushing {cfg.index_name}...")
-        start = time.time()
+        start = time.perf_counter()
         response = requests.post(f"{self.base_url}/{cfg.index_name}/_flush", timeout=600)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         if response.status_code == 200:
             logger.info(f"Flush completed in {elapsed:.1f}s [OK]")
         else:
@@ -228,9 +228,9 @@ class OpenSearchEngine(VectorSearchEngine):
     def refresh_index(self) -> None:
         cfg = self.dataset_config
         logger.info(f"Refreshing {cfg.index_name}...")
-        start = time.time()
+        start = time.perf_counter()
         response = requests.post(f"{self.base_url}/{cfg.index_name}/_refresh", timeout=600)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         if response.status_code == 200:
             logger.info(f"Refresh completed in {elapsed:.1f}s [OK]")
         else:
@@ -239,9 +239,9 @@ class OpenSearchEngine(VectorSearchEngine):
     def close_index(self) -> None:
         cfg = self.dataset_config
         logger.info(f"Closing {cfg.index_name}...")
-        start = time.time()
+        start = time.perf_counter()
         response = requests.post(f"{self.base_url}/{cfg.index_name}/_close", timeout=600)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         if response.status_code == 200:
             logger.info(f"Close completed in {elapsed:.1f}s [OK]")
         else:
@@ -250,9 +250,9 @@ class OpenSearchEngine(VectorSearchEngine):
     def open_index(self) -> None:
         cfg = self.dataset_config
         logger.info(f"Opening {cfg.index_name}...")
-        start = time.time()
+        start = time.perf_counter()
         response = requests.post(f"{self.base_url}/{cfg.index_name}/_open", timeout=600)
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         if response.status_code == 200:
             logger.info(f"Open completed in {elapsed:.1f}s [OK]")
         else:

--- a/src/search_ann_benchmark/engines/pgvector.py
+++ b/src/search_ann_benchmark/engines/pgvector.py
@@ -74,9 +74,9 @@ class PgvectorEngine(VectorSearchEngine):
         import psycopg
 
         logger.info(f"Waiting for {self.engine_config.container_name}...")
-        start = time.time()
+        start = time.perf_counter()
         for attempt in range(timeout):
-            elapsed = time.time() - start
+            elapsed = time.perf_counter() - start
             try:
                 logger.debug(f"Health check attempt {attempt+1}/{timeout}, elapsed={elapsed:.1f}s")
                 with psycopg.connect(self.pg_config.conninfo) as conn:
@@ -144,11 +144,11 @@ class PgvectorEngine(VectorSearchEngine):
         else:
             create_idx = f"CREATE INDEX ON {cfg.index_name} USING hnsw (embedding {vector_ops}) WITH (m = {cfg.hnsw_m}, ef_construction = {cfg.hnsw_ef_construction});"
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         with psycopg.connect(f"dbname={pg_cfg.dbname} {pg_cfg.conninfo}") as conn:
             conn.execute(create_idx)
             conn.execute(f"CREATE INDEX ON {cfg.index_name} (section);")
-        elapsed = time.time() - start_time
+        elapsed = time.perf_counter() - start_time
         print(f"[OK] {elapsed:.2f}s")
 
     def wait_for_indexing_complete(self) -> None:
@@ -207,14 +207,14 @@ class PgvectorEngine(VectorSearchEngine):
             buffer.write(f"{doc_id}\t{page_id}\t{rev_id}\t{section}\t{embedding_str}\n")
         buffer.seek(0)
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         try:
             with psycopg.connect(f"dbname={pg_cfg.dbname} {pg_cfg.conninfo}") as conn:
                 with conn.cursor() as cur:
                     with cur.copy(f"COPY {cfg.index_name} (doc_id, page_id, rev_id, section, embedding) FROM STDIN") as copy:
                         copy.write(buffer.read())
                     conn.commit()
-                    elapsed = time.time() - start_time
+                    elapsed = time.perf_counter() - start_time
                     print(f"[OK] {elapsed:.3f}s")
                     return elapsed
         except Exception as e:
@@ -260,7 +260,7 @@ class PgvectorEngine(VectorSearchEngine):
             LIMIT {top_k};
         """
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         try:
             conn = self._get_connection()
             with conn.cursor() as cur:
@@ -270,7 +270,7 @@ class PgvectorEngine(VectorSearchEngine):
                     cur.execute("SET LOCAL hnsw.iterative_scan = relaxed_order;")
                 cur.execute(query, tuple(params))
                 docs = cur.fetchall()
-                took_ms = (time.time() - start_time) * 1000
+                took_ms = (time.perf_counter() - start_time) * 1000
                 cur.execute("COMMIT;")
 
                 return SearchResult(

--- a/src/search_ann_benchmark/engines/qdrant.py
+++ b/src/search_ann_benchmark/engines/qdrant.py
@@ -61,9 +61,9 @@ class QdrantEngine(VectorSearchEngine):
 
     def wait_until_ready(self, timeout: int = 60) -> bool:
         logger.info(f"Waiting for {self.engine_config.container_name}...")
-        start = time.time()
+        start = time.perf_counter()
         for attempt in range(timeout):
-            elapsed = time.time() - start
+            elapsed = time.perf_counter() - start
             try:
                 logger.debug(f"Health check attempt {attempt+1}/{timeout}, elapsed={elapsed:.1f}s")
                 response = requests.get(f"{self.base_url}/cluster", timeout=5)

--- a/src/search_ann_benchmark/engines/redisstack.py
+++ b/src/search_ann_benchmark/engines/redisstack.py
@@ -67,9 +67,9 @@ class RedisStackEngine(VectorSearchEngine):
         import redis
 
         logger.info(f"Waiting for {self.engine_config.container_name}...")
-        start = time.time()
+        start = time.perf_counter()
         for attempt in range(timeout):
-            elapsed = time.time() - start
+            elapsed = time.perf_counter() - start
             try:
                 logger.debug(f"Health check attempt {attempt+1}/{timeout}, elapsed={elapsed:.1f}s")
                 client = redis.Redis(
@@ -176,7 +176,7 @@ class RedisStackEngine(VectorSearchEngine):
         client = self._get_client()
         pipeline = client.pipeline(transaction=False)
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         try:
             for doc, embedding, doc_id in zip(documents, embeddings, ids):
                 key = f"doc:{doc_id}"
@@ -196,7 +196,7 @@ class RedisStackEngine(VectorSearchEngine):
                 pipeline.hset(key, mapping=fields)
 
             pipeline.execute()
-            elapsed = time.time() - start_time
+            elapsed = time.perf_counter() - start_time
             print(f"[OK] {elapsed:.3f}s")
             return elapsed
         except Exception as e:
@@ -227,7 +227,7 @@ class RedisStackEngine(VectorSearchEngine):
         else:
             query_str = "*=>[KNN $K @embedding $BLOB EF_RUNTIME $EF]"
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         try:
             # FT.SEARCH idx query PARAMS 6 K top_k BLOB bytes EF ef SORTBY __embedding_score
             result = client.execute_command(
@@ -240,7 +240,7 @@ class RedisStackEngine(VectorSearchEngine):
                 "LIMIT", "0", str(top_k),
                 "DIALECT", "2",
             )
-            took_ms = (time.time() - start_time) * 1000
+            took_ms = (time.perf_counter() - start_time) * 1000
 
             # Parse result: [total_hits, doc_key1, [field1, value1, ...], doc_key2, ...]
             total_hits = result[0]

--- a/src/search_ann_benchmark/engines/vald.py
+++ b/src/search_ann_benchmark/engines/vald.py
@@ -209,9 +209,9 @@ ngt:
             return False
 
         logger.info(f"Waiting for {self.vald_config.container_name}...")
-        start = time.time()
+        start = time.perf_counter()
         for attempt in range(timeout):
-            elapsed = time.time() - start
+            elapsed = time.perf_counter() - start
             try:
                 logger.debug(f"Health check attempt {attempt + 1}/{timeout}, elapsed={elapsed:.1f}s")
                 # Check liveness endpoint
@@ -346,14 +346,14 @@ ngt:
 
         multi_request = payload_pb2.Insert.MultiRequest(requests=requests_list)
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         try:
             self._insert_stub.MultiInsert(multi_request)
-            elapsed = time.time() - start_time
+            elapsed = time.perf_counter() - start_time
             print(f"[OK] {elapsed:.3f}s")
             return elapsed
         except Exception as e:
-            elapsed = time.time() - start_time
+            elapsed = time.perf_counter() - start_time
             print(f"[FAIL] {e}")
             logger.error(f"Insert failed: {e}")
             return elapsed
@@ -388,10 +388,10 @@ ngt:
             config=config,
         )
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         try:
             response = self._search_stub.Search(request)
-            elapsed = (time.time() - start_time) * 1000  # Convert to ms
+            elapsed = (time.perf_counter() - start_time) * 1000  # Convert to ms
 
             results = response.results
 
@@ -425,7 +425,7 @@ ngt:
                 scores=[r.distance for r in results],
             )
         except Exception as e:
-            elapsed = (time.time() - start_time) * 1000
+            elapsed = (time.perf_counter() - start_time) * 1000
             logger.error(f"Search failed: {e}")
             return SearchResult(query_id=0, took_ms=elapsed, hits=0, ids=[], scores=[])
 
@@ -449,7 +449,7 @@ ngt:
 
         # Wait for index to stabilize
         logger.debug(f"Waiting for indexing to complete (stable_count={stable_count}, interval={check_interval}s)")
-        start = time.time()
+        start = time.perf_counter()
         count = 0
         total_checks = 0
         last_stored = 0
@@ -470,7 +470,7 @@ ngt:
                     count = 0
                     last_stored = stored
 
-                elapsed = time.time() - start
+                elapsed = time.perf_counter() - start
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.debug(
                         f"Indexing check {total_checks}: stored={stored}, uncommitted={uncommitted}, stable_count={count}/{stable_count}, elapsed={elapsed:.1f}s"
@@ -483,7 +483,7 @@ ngt:
 
             time.sleep(check_interval)
 
-        elapsed = time.time() - start
+        elapsed = time.perf_counter() - start
         if not logger.isEnabledFor(logging.DEBUG):
             print(".")
         logger.debug(f"Indexing complete after {total_checks} checks in {elapsed:.1f}s")

--- a/src/search_ann_benchmark/engines/vespa.py
+++ b/src/search_ann_benchmark/engines/vespa.py
@@ -80,9 +80,9 @@ class VespaEngine(VectorSearchEngine):
 
     def wait_until_ready(self, timeout: int = 60) -> bool:
         logger.info(f"Waiting for {self.engine_config.container_name}...")
-        start = time.time()
+        start = time.perf_counter()
         for attempt in range(timeout):
-            elapsed = time.time() - start
+            elapsed = time.perf_counter() - start
             try:
                 logger.debug(f"Health check attempt {attempt+1}/{timeout}, elapsed={elapsed:.1f}s")
                 response = requests.get(f"{self.management_url}/state/v1/health", timeout=5)
@@ -300,9 +300,9 @@ schema {cfg.index_name} {{
                 "vespa", "feed", str(temp_path),
                 "--target", self.base_url,
             ]
-            start_time = time.time()
+            start_time = time.perf_counter()
             result = subprocess.run(vespa_cmd, capture_output=True, text=True)
-            elapsed = time.time() - start_time
+            elapsed = time.perf_counter() - start_time
 
             if result.returncode == 0 and self._check_error_counts(result.stdout):
                 print(f"[OK] {elapsed:.2f}s")
@@ -354,7 +354,7 @@ schema {cfg.index_name} {{
             payload = {"fields": {**doc, "embedding": {"values": embedding}}}
             requests_data.append((doc_url, payload))
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         success_count = 0
         fail_count = 0
 
@@ -371,7 +371,7 @@ schema {cfg.index_name} {{
                     else:
                         fail_count += 1
 
-        elapsed = time.time() - start_time
+        elapsed = time.perf_counter() - start_time
 
         if fail_count == 0:
             print(f"[OK] {elapsed:.2f}s")

--- a/src/search_ann_benchmark/engines/weaviate.py
+++ b/src/search_ann_benchmark/engines/weaviate.py
@@ -67,9 +67,9 @@ class WeaviateEngine(VectorSearchEngine):
 
     def wait_until_ready(self, timeout: int = 60) -> bool:
         logger.info(f"Waiting for {self.engine_config.container_name}...")
-        start = time.time()
+        start = time.perf_counter()
         for attempt in range(timeout):
-            elapsed = time.time() - start
+            elapsed = time.perf_counter() - start
             try:
                 logger.debug(f"Health check attempt {attempt+1}/{timeout}, elapsed={elapsed:.1f}s")
                 response = requests.get(f"{self.base_url}/v1/nodes", timeout=5)
@@ -168,13 +168,13 @@ class WeaviateEngine(VectorSearchEngine):
             for doc, embedding, doc_id in zip(documents, embeddings, ids)
         ]
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         response = requests.post(
             f"{self.base_url}/v1/batch/objects",
             headers={"Content-Type": "application/json"},
             json={"objects": objects},
         )
-        elapsed = time.time() - start_time
+        elapsed = time.perf_counter() - start_time
 
         if response.status_code == 200:
             # Check for partial failures in batch response
@@ -222,13 +222,13 @@ class WeaviateEngine(VectorSearchEngine):
   }}
 }}"""
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         response = self._get_session().post(
             f"{self.base_url}/v1/graphql",
             json={"query": query},
             timeout=10,
         )
-        took_ms = (time.time() - start_time) * 1000
+        took_ms = (time.perf_counter() - start_time) * 1000
 
         if response.status_code == 200:
             obj = response.json()

--- a/src/search_ann_benchmark/runner.py
+++ b/src/search_ann_benchmark/runner.py
@@ -13,10 +13,11 @@ import numpy as np
 import pandas as pd
 
 from search_ann_benchmark.config import DatasetConfig, get_dataset_config
-from search_ann_benchmark.core.base import VectorSearchEngine
+from search_ann_benchmark.core.base import SearchResult, VectorSearchEngine
 from search_ann_benchmark.core.docker import DockerManager
 from search_ann_benchmark.core.embedding import ContentLoader, EmbeddingLoader
 from search_ann_benchmark.core.logging import get_logger
+from search_ann_benchmark.core.measurement import low_noise_measurement
 from search_ann_benchmark.core.metrics import (
     BenchmarkMetrics,
     MetricsCalculator,
@@ -76,11 +77,11 @@ class BenchmarkRunner:
 
         # Wait for engine to be ready
         logger.debug("Calling wait_until_ready()")
-        start = time.time()
+        start = time.perf_counter()
         if not self.engine.wait_until_ready():
-            logger.error(f"Failed to start {self.engine.engine_name} after {time.time()-start:.1f}s")
+            logger.error(f"Failed to start {self.engine.engine_name} after {time.perf_counter()-start:.1f}s")
             raise RuntimeError(f"Failed to start {self.engine.engine_name}")
-        logger.debug(f"Engine ready after {time.time()-start:.1f}s")
+        logger.debug(f"Engine ready after {time.perf_counter()-start:.1f}s")
 
     def create_index(self) -> None:
         """Create the search index."""
@@ -92,9 +93,9 @@ class BenchmarkRunner:
             self.engine.create_database()
 
         logger.debug("Creating index...")
-        start = time.time()
+        start = time.perf_counter()
         self.engine.create_index()
-        logger.debug(f"Index created in {time.time()-start:.1f}s")
+        logger.debug(f"Index created in {time.perf_counter()-start:.1f}s")
 
         # Wait for index to be ready if needed
         if hasattr(self.engine, "wait_for_index_ready"):
@@ -126,7 +127,7 @@ class BenchmarkRunner:
         logger.debug(f"Loading embeddings from {cfg.embedding_path}")
         logger.debug(f"Target index size: {cfg.index_size}, bulk size: {cfg.bulk_size}")
 
-        start_time = time.time()
+        start_time = time.perf_counter()
         total_process_time = 0.0
 
         documents: list[dict[str, Any]] = []
@@ -154,11 +155,11 @@ class BenchmarkRunner:
 
             if len(ids) >= cfg.bulk_size:
                 batch_num += 1
-                batch_start = time.time()
+                batch_start = time.perf_counter()
                 logger.debug(f"Inserting batch {batch_num}: {len(ids)} docs (total: {count})")
                 t = self.engine.insert_documents(documents, embeddings, ids)
                 total_process_time += t
-                logger.debug(f"Batch {batch_num} completed in {time.time()-batch_start:.2f}s (process_time: {t:.2f}s)")
+                logger.debug(f"Batch {batch_num} completed in {time.perf_counter()-batch_start:.2f}s (process_time: {t:.2f}s)")
                 documents = []
                 embeddings = []
                 ids = []
@@ -166,19 +167,19 @@ class BenchmarkRunner:
         # Insert remaining documents
         if ids:
             batch_num += 1
-            batch_start = time.time()
+            batch_start = time.perf_counter()
             logger.debug(f"Inserting final batch {batch_num}: {len(ids)} docs (total: {count})")
             t = self.engine.insert_documents(documents, embeddings, ids)
             total_process_time += t
-            logger.debug(f"Final batch completed in {time.time()-batch_start:.2f}s (process_time: {t:.2f}s)")
+            logger.debug(f"Final batch completed in {time.perf_counter()-batch_start:.2f}s (process_time: {t:.2f}s)")
 
         # Wait for indexing to complete
         logger.debug("Calling wait_for_indexing_complete()")
-        wait_start = time.time()
+        wait_start = time.perf_counter()
         self.engine.wait_for_indexing_complete()
-        logger.debug(f"Indexing complete wait finished in {time.time()-wait_start:.1f}s")
+        logger.debug(f"Indexing complete wait finished in {time.perf_counter()-wait_start:.1f}s")
 
-        execution_time = time.time() - start_time
+        execution_time = time.perf_counter() - start_time
         hours, remainder = divmod(execution_time, 3600)
         minutes, seconds = divmod(remainder, 60)
         logger.info(f"Indexing complete: {count} docs in {int(hours):02d}:{int(minutes):02d}:{seconds:02.2f} (process_time: {timedelta(seconds=total_process_time)})")
@@ -228,7 +229,7 @@ class BenchmarkRunner:
             if with_filter and self.section_values:
                 warmup_filter = self.engine.get_filter_generator(self.section_values)
             logger.info(f"Running {warmup_count} warmup queries...")
-            warmup_start = time.time()
+            warmup_start = time.perf_counter()
             self._run_queries(
                 output_path=None,
                 max_size=warmup_count,
@@ -236,14 +237,14 @@ class BenchmarkRunner:
                 offset=0,
                 filter_generator=warmup_filter,
             )
-            logger.debug(f"Warmup completed in {time.time()-warmup_start:.1f}s")
+            logger.debug(f"Warmup completed in {time.perf_counter()-warmup_start:.1f}s")
 
             # Run actual benchmark with fresh filter generator
             actual_filter = None
             if with_filter and self.section_values:
                 actual_filter = self.engine.get_filter_generator(self.section_values)
             logger.info(f"Running {query_count} queries...")
-            benchmark_start = time.time()
+            benchmark_start = time.perf_counter()
             self._run_queries(
                 output_path=output_filename,
                 max_size=query_count,
@@ -251,7 +252,7 @@ class BenchmarkRunner:
                 offset=cfg.index_size,
                 filter_generator=actual_filter,
             )
-            logger.debug(f"Benchmark queries completed in {time.time()-benchmark_start:.1f}s")
+            logger.debug(f"Benchmark queries completed in {time.perf_counter()-benchmark_start:.1f}s")
 
             # Calculate metrics
             metrics = self._metrics_calculator.calculate_from_file(
@@ -269,6 +270,61 @@ class BenchmarkRunner:
 
         return search_results
 
+    def _iter_query_batches(
+        self,
+        offset: int,
+        normalize: bool,
+    ) -> Generator[tuple[list[int], list[list[float]]], None, None]:
+        """Yield successive batches of (doc_ids, preprocessed query vectors).
+
+        All vector preprocessing (dtype cast, normalization, list conversion)
+        happens here so the measurement loop only has to call ``engine.search``.
+        Embedding shards are yielded in their on-disk order, wrapping back to
+        ``0.npz`` once ``num_of_docs`` is exhausted. The consumer is expected
+        to stop iterating once it has accumulated enough successful queries.
+
+        Args:
+            offset: Starting offset in embeddings
+            normalize: Whether to L2-normalize each vector
+
+        Yields:
+            ``(doc_ids, query_vectors)`` pairs. Each batch corresponds to one
+            ``.npz`` shard.
+        """
+        cfg = self.engine.dataset_config
+        doc_id = 0
+        pos = offset
+
+        while True:
+            npz_path = cfg.embedding_path / f"{pos}.npz"
+            if not npz_path.exists():
+                if pos == 0:
+                    raise FileNotFoundError(
+                        f"Embedding file not found: {npz_path}. "
+                        "Run 'bash scripts/setup.sh' to download the dataset."
+                    )
+                pos = 0
+                continue
+
+            with np.load(npz_path) as data:
+                raw = data["embs"]
+
+            shard_f32 = raw.astype(np.float32, copy=False)
+            if normalize:
+                norms = np.linalg.norm(shard_f32, axis=1, keepdims=True)
+                # Guard against zero vectors that would otherwise produce NaNs.
+                norms = np.where(norms == 0, 1.0, norms)
+                shard_f32 = shard_f32 / norms
+
+            doc_ids = list(range(doc_id + 1, doc_id + 1 + len(shard_f32)))
+            doc_id += len(shard_f32)
+
+            yield doc_ids, shard_f32.tolist()
+
+            pos += 100000
+            if pos > cfg.num_of_docs:
+                pos = 0
+
     def _run_queries(
         self,
         output_path: str | None,
@@ -279,6 +335,13 @@ class BenchmarkRunner:
     ) -> None:
         """Run search queries.
 
+        The per-query measurement loop is intentionally minimal: query vector
+        preprocessing, filter generation, result buffering, progress logging,
+        and disk writes are deliberately performed outside the search call so
+        they do not contribute to per-query latency jitter. Each engine still
+        measures its own ``took_ms`` internally; the runner just avoids adding
+        noise around that measurement.
+
         Args:
             output_path: Path to write results (None for warmup)
             max_size: Maximum number of queries
@@ -287,87 +350,108 @@ class BenchmarkRunner:
             filter_generator: Optional filter query generator
         """
         cfg = self.engine.dataset_config
-        start_time = time.time()
-        count = 0
-        doc_id = 0
-        pos = offset
-        running = True
+        normalize = cfg.distance in (
+            "dot_product", "Dot", "IP", "ip", "<#>", "dotproduct",
+        )
 
-        writer = None
         if output_path:
             Path(output_path).parent.mkdir(parents=True, exist_ok=True)
-            writer = SearchResultsWriter(output_path)
-            writer.__enter__()
 
+        # Preallocate per-batch result buffers so disk writes can be deferred
+        # until after the timed window.
+        debug_progress = logger.isEnabledFor(logging.DEBUG)
+        progress_every = 1000 if debug_progress else 10000
+        engine_search = self.engine.search  # local alias to skip attribute lookup
+
+        start_time = time.perf_counter()
+        count = 0
+        progress_start = start_time
+
+        writer = SearchResultsWriter(output_path) if output_path else None
         try:
-            while running:
-                npz_path = cfg.embedding_path / f"{pos}.npz"
-                if not npz_path.exists():
-                    if pos == 0:
-                        raise FileNotFoundError(f"Embedding file not found: {npz_path}. Run 'bash scripts/setup.sh' to download the dataset.")
-                    pos = 0
-                    continue
+            if writer:
+                writer.__enter__()
 
-                with np.load(npz_path) as data:
-                    embeddings = data["embs"]
-
-                for embedding in embeddings:
-                    doc_id += 1
-                    if count >= max_size:
-                        running = False
+            with low_noise_measurement():
+                batch_iter = self._iter_query_batches(offset=offset, normalize=normalize)
+                done = False
+                for doc_ids, query_vectors in batch_iter:
+                    if done:
                         break
 
-                    embedding = embedding.astype(np.float32)
-                    if cfg.distance in ("dot_product", "Dot", "IP", "ip", "<#>", "dotproduct"):
-                        embedding = embedding / np.linalg.norm(embedding)
+                    # Cap the batch so we never run more queries than needed.
+                    remaining = max_size - count
+                    if remaining <= 0:
+                        break
+                    if remaining < len(query_vectors):
+                        doc_ids = doc_ids[:remaining]
+                        query_vectors = query_vectors[:remaining]
 
-                    filter_query = None
-                    if filter_generator:
-                        filter_query = next(filter_generator)
+                    # Pre-generate filter queries for the whole batch so the
+                    # generator's overhead is outside the timed search call.
+                    if filter_generator is not None:
+                        filter_queries: list[dict[str, Any] | None] = [
+                            next(filter_generator) for _ in query_vectors
+                        ]
+                    else:
+                        filter_queries = [None] * len(query_vectors)
 
-                    result = self.engine.search(
-                        query_vector=embedding.tolist(),
-                        top_k=page_size,
-                        filter_query=filter_query,
-                    )
-
-                    if result.took_ms == -1:
-                        continue
-
-                    if writer:
-                        writer.write_result(
-                            query_id=doc_id,
-                            took=result.took_ms,
-                            hits=result.hits,
-                            ids=result.ids,
-                            scores=result.scores,
-                            total_hits=result.total_hits,
+                    batch_results: list[tuple[int, SearchResult]] = []
+                    for doc_id, query_vector, filter_query in zip(
+                        doc_ids, query_vectors, filter_queries,
+                    ):
+                        # === Hot measurement region: keep this minimal ===
+                        result = engine_search(
+                            query_vector=query_vector,
+                            top_k=page_size,
+                            filter_query=filter_query,
                         )
+                        # =================================================
+                        batch_results.append((doc_id, result))
 
-                    count += 1
-                    if logger.isEnabledFor(logging.DEBUG):
-                        if count % 1000 == 0:
-                            elapsed = time.time() - start_time
-                            qps = count / elapsed if elapsed > 0 else 0
-                            logger.debug(f"Query progress: {count}/{max_size} ({qps:.1f} qps, elapsed={elapsed:.1f}s)")
-                    elif count % 10000 == 0:
-                        elapsed = time.time() - start_time
-                        qps = count / elapsed if elapsed > 0 else 0
-                        logger.info(f"Sent {count}/{max_size} queries ({qps:.1f} qps)")
-
-                pos += 100000
-                if pos > cfg.num_of_docs:
-                    pos = 0
-
+                    # All bookkeeping (validation, IO, logging) happens out
+                    # of the timed window.
+                    for doc_id, result in batch_results:
+                        if result.took_ms == -1:
+                            continue
+                        if writer:
+                            writer.write_result(
+                                query_id=doc_id,
+                                took=result.took_ms,
+                                hits=result.hits,
+                                ids=result.ids,
+                                scores=result.scores,
+                                total_hits=result.total_hits,
+                            )
+                        count += 1
+                        if count >= max_size:
+                            done = True
+                        if count % progress_every == 0:
+                            now = time.perf_counter()
+                            window = now - progress_start
+                            qps = progress_every / window if window > 0 else 0.0
+                            msg = (
+                                f"Query progress: {count}/{max_size} "
+                                f"({qps:.1f} qps over last {progress_every}, "
+                                f"window={window:.2f}s)"
+                            )
+                            if debug_progress:
+                                logger.debug(msg)
+                            else:
+                                logger.info(msg)
+                            progress_start = now
         finally:
             if writer:
                 writer.__exit__(None, None, None)
 
-        execution_time = time.time() - start_time
+        execution_time = time.perf_counter() - start_time
         hours, remainder = divmod(execution_time, 3600)
         minutes, seconds = divmod(remainder, 60)
         qps = count / execution_time if execution_time > 0 else 0
-        logger.info(f"Queries complete: {count} queries in {int(hours):02d}:{int(minutes):02d}:{seconds:02.2f} ({qps:.1f} qps)")
+        logger.info(
+            f"Queries complete: {count} queries in "
+            f"{int(hours):02d}:{int(minutes):02d}:{seconds:02.2f} ({qps:.1f} qps)"
+        )
 
     def _get_ground_truth_filename(self, page_size: int, with_filter: bool) -> str:
         """Get ground truth filename for precision calculation."""


### PR DESCRIPTION
## Summary
- Switch all elapsed-time measurements from `time.time()` to the monotonic `time.perf_counter()` across the runner, core helpers, and every engine adapter. The wall-clock source was susceptible to NTP adjustments and offered no benefit for delta calculations.
- Minimize the timed region in `runner._run_queries` so only `engine.search()` is inside the window. Filter generation, batch dtype/normalization, result validation, `SearchResultsWriter.write_result`, and progress logging now run outside the measurement. Progress logs become rolling-window QPS reports between samples.
- Add `core/measurement.py` with a `low_noise_measurement()` context manager (default-enabled in the benchmark phase) that:
  - runs `gc.collect()` then `gc.disable()` for the duration of the window,
  - attempts `os.nice(-10)` (warns on `PermissionError`, continues),
  - pins the process to a single CPU core via `os.sched_setaffinity` on Linux (warns and continues if unsupported or denied),
  - restores GC state and CPU affinity on exit.
- Output schema is unchanged: `took` remains milliseconds as float in `results.json`.

## Test plan
- [x] `uv run pytest` — 19/19 pass
- [x] `rg "time\\.time\\(\\)" src/` — zero remaining occurrences (only elapsed-time call sites existed)
- [x] `uv run ruff check src` — 25 errors, same as `main` baseline (no new errors)
- [ ] Run an actual benchmark against one engine (e.g. `uv run search-ann-benchmark run qdrant --target 100k-768-m32-efc200-ef100-ip`) and confirm `results.json` `took` distribution looks reasonable and per-engine workflows still complete
- [ ] Verify behavior on a non-Linux host that `sched_setaffinity` skip path logs a warning and continues
- [ ] Verify the unprivileged path: confirm the `os.nice` warning fires cleanly when run without elevated permissions