### PR TITLE
chore(elasticsearch): bump Elasticsearch version from 9.4.1 to 9.4.2

### DIFF
--- a/.github/workflows/run-elasticsearch-bbq-disk-2bit-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-disk-2bit-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.4.1"
+  ENGINE_VERSION: "9.4.2"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-bbq-disk-4bit-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-disk-4bit-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.4.1"
+  ENGINE_VERSION: "9.4.2"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-bbq-disk-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-disk-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.4.1"
+  ENGINE_VERSION: "9.4.2"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-bbq-linux.yml
+++ b/.github/workflows/run-elasticsearch-bbq-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.4.1"
+  ENGINE_VERSION: "9.4.2"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-int4-linux.yml
+++ b/.github/workflows/run-elasticsearch-int4-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.4.1"
+  ENGINE_VERSION: "9.4.2"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-int8-linux.yml
+++ b/.github/workflows/run-elasticsearch-int8-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.4.1"
+  ENGINE_VERSION: "9.4.2"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-elasticsearch-linux.yml
+++ b/.github/workflows/run-elasticsearch-linux.yml
@@ -49,7 +49,7 @@ on:
 
 env:
   ENGINE_NAME: elasticsearch
-  ENGINE_VERSION: "9.4.1"
+  ENGINE_VERSION: "9.4.2"
 
 jobs:
   benchmark:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This benchmarking suite aims to provide an empirical basis for comparing the per
 | Engine | Version | GitHub Actions |
 |--------|---------|----------------|
 | Qdrant | 1.18.0 | [![Run Qdrant](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml) |
-| Elasticsearch | 9.4.1 | [![Run Elasticsearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml) |
+| Elasticsearch | 9.4.2 | [![Run Elasticsearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml) |
 | OpenSearch | 3.6.0 | [![Run OpenSearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml) |
 | Milvus | 2.6.14 | [![Run Milvus](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml) |
 | Weaviate | 1.36.9 | [![Run Weaviate](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-weaviate-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-weaviate-linux.yml) |

--- a/src/search_ann_benchmark/engines/elasticsearch.py
+++ b/src/search_ann_benchmark/engines/elasticsearch.py
@@ -22,7 +22,7 @@ class ElasticsearchConfig(EngineConfig):
     name: str = "elasticsearch"
     host: str = "localhost"
     port: int = 9211
-    version: str = "9.4.1"
+    version: str = "9.4.2"
     container_name: str = "benchmark_es"
     heap: str = "2g"
 


### PR DESCRIPTION
## Summary

Bumps the benchmarked Elasticsearch version from **9.4.1** to **9.4.2** (latest stable patch release).

Version is kept in sync across all three locations:

- `src/search_ann_benchmark/engines/elasticsearch.py` — `version` field
- `README.md` — Supported Engines table
- 7 workflow files: `run-elasticsearch{,-int8,-int4,-bbq,-bbq-disk,-bbq-disk-2bit,-bbq-disk-4bit}-linux.yml` — `ENGINE_VERSION`

## Release Notes (9.4.2)

Patch release. Relevant area highlights:

- **Vector Search**: fixed GPU resource closing order; GPU codec falls back to CPU graph build on flush when the GPU is busy — GPU-only, does not affect this CPU-HNSW benchmark.
- Assorted ML, ES|QL, aggregation, and inference bug fixes unrelated to this benchmark.
- Infra: upgraded to log4j 2.26.0.

## Breaking Changes

None. No changes to the `dense_vector`, kNN, or quantization (int4/int8/bbq/bbq_disk) APIs used by this engine.

## Additional Code Changes

None — pure version-string bump.

https://claude.ai/code/session_01Sv6zFYr5emHPKnYoHEyGcj