### PR TITLE
chore(opensearch): bump OpenSearch version from 3.6.0 to 3.7.0

### DIFF
--- a/.github/workflows/run-opensearch-faiss-linux.yml
+++ b/.github/workflows/run-opensearch-faiss-linux.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   ENGINE_NAME: opensearch
-  ENGINE_VERSION: "3.6.0"
+  ENGINE_VERSION: "3.7.0"
 
 jobs:
   benchmark:

--- a/.github/workflows/run-opensearch-linux.yml
+++ b/.github/workflows/run-opensearch-linux.yml
@@ -47,7 +47,7 @@ on:
 
 env:
   ENGINE_NAME: opensearch
-  ENGINE_VERSION: "3.6.0"
+  ENGINE_VERSION: "3.7.0"
 
 jobs:
   benchmark:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This benchmarking suite aims to provide an empirical basis for comparing the per
 |--------|---------|----------------|
 | Qdrant | 1.18.0 | [![Run Qdrant](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-qdrant-linux.yml) |
 | Elasticsearch | 9.4.2 | [![Run Elasticsearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-elasticsearch-linux.yml) |
-| OpenSearch | 3.6.0 | [![Run OpenSearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml) |
+| OpenSearch | 3.7.0 | [![Run OpenSearch](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-opensearch-linux.yml) |
 | Milvus | 2.6.14 | [![Run Milvus](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-milvus-linux.yml) |
 | Weaviate | 1.36.9 | [![Run Weaviate](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-weaviate-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-weaviate-linux.yml) |
 | Vespa | 8.687.75 | [![Run Vespa](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-vespa-linux.yml/badge.svg)](https://github.com/codelibs/search-ann-benchmark/actions/workflows/run-vespa-linux.yml) |

--- a/src/search_ann_benchmark/engines/opensearch.py
+++ b/src/search_ann_benchmark/engines/opensearch.py
@@ -23,7 +23,7 @@ class OpenSearchConfig(EngineConfig):
     name: str = "opensearch"
     host: str = "localhost"
     port: int = 9212
-    version: str = "3.6.0"
+    version: str = "3.7.0"
     container_name: str = "benchmark_opensearch"
     heap: str = "2g"
     engine: str = "lucene"  # or "faiss"


### PR DESCRIPTION
## Summary

Bumps OpenSearch from **3.6.0** to **3.7.0** (latest stable release).

Updated all three version locations to keep them in sync:

- `src/search_ann_benchmark/engines/opensearch.py` — `version` field
- `.github/workflows/run-opensearch-linux.yml` — `ENGINE_VERSION`
- `.github/workflows/run-opensearch-faiss-linux.yml` — `ENGINE_VERSION`
- `README.md` — Supported Engines version table

## Release Notes (3.7.0)

- `extra_fields` outside `_source` for improved vector ingestion throughput (#20635)
- `queryTimeout` on `IndexSearcher` for k-NN vector search timeout enforcement (#21316)
- Native memory / admission control improvements benefiting memory-intensive vector operations

## Breaking Changes

None detected. No k-NN API changes, no new required configuration, and no Docker image/port changes. The Docker tag `3.7.0` is available for both linux/amd64 and linux/arm64.

## Additional Code Changes

None needed — the benchmark uses the standard k-NN REST API (lucene/faiss engines), which is unaffected.